### PR TITLE
Use site email address if no recipient is specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.0a3 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Use site email address as default recipient address also for Plone 5.
+  [tmassman]
 
 
 2.0.0a2 (2016-10-14)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -15,3 +15,4 @@ Google Summer of Code student Prakhar Joshi pushed a lot further.
 - Nathan Van Gheem, vangheem@gmail.com
 - Jens W. Klein, jens@bluedynamics.com
 - Peter Holzer, peter.holzer@agitator.com
+- Thomas Massmann, thomas.massmann@it-spir.it

--- a/src/collective/easyform/actions.py
+++ b/src/collective/easyform/actions.py
@@ -230,8 +230,15 @@ class Mailer(Action):
         if userdest is not None:
             toemail = userdest.getProperty('email', '')
         if not toemail:
+            pprops = getToolByName(context, 'portal_properties')
+            site_props = getToolByName(pprops, 'site_properties')
             portal = getToolByName(context, 'portal_url').getPortalObject()
-            toemail = portal.getProperty('email_from_address')
+            registry = getUtility(IRegistry)
+            toemail = (
+                site_props.getProperty('email_from_address') or
+                portal.getProperty('email_from_address') or
+                registry.get('plone.email_from_address')
+            )
         if not toemail:
             raise ValueError(
                 u"Unable to mail form input because no recipient address has "


### PR DESCRIPTION
The current implementation was missing the recipient email address fallback for Plone 5. It was only implemented for the `from_address`.

The `ValueError` is still shown if there is no email address provided in the portal mail settings.
