### PR TITLE
removing i18 tags for initial fields

### DIFF
--- a/src/collective/easyform/default_schemata/fields_default.xml
+++ b/src/collective/easyform/default_schemata/fields_default.xml
@@ -11,15 +11,15 @@
         easyform:serverSide="False"
         easyform:validators="isValidEmail">
       <description/>
-      <title i18n:translate="">Your E-Mail Address</title>
+      <title>Your E-Mail Address</title>
     </field>
     <field name="topic" type="zope.schema.TextLine">
       <description/>
-      <title i18n:translate="">Subject</title>
+      <title>Subject</title>
     </field>
     <field name="comments" type="zope.schema.Text">
       <description/>
-      <title i18n:translate="">Comments</title>
+      <title>Comments</title>
     </field>
   </schema>
 </model>


### PR DESCRIPTION
Translate tags don't work for a non-english sites. With this tag, changing the Field label on languages other than english doesn't work. Tested on german Site and with plone.app.multilingual