### PR TITLE
New checkbox to send csv attachment of form data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,9 @@ New features:
 - Allow default fields, actions & mailtemplate in DB
   [tomgross]
 
+- New mailer adapter checkbox to send CSV data attachment
+  [tkimnguyen]
+
 Bug fixes:
 
 - Support ``showAll`` and ``includeEmpties`` also for the thanks page.

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -16,4 +16,5 @@ Google Summer of Code student Prakhar Joshi pushed a lot further.
 - Jens W. Klein, jens@bluedynamics.com
 - Peter Holzer, peter.holzer@agitator.com
 - Thomas Massmann, thomas.massmann@it-spir.it
+- T. Kim Nguyen, kim.nguyen@wildcardcorp.com
 

--- a/src/collective/easyform/interfaces/mailer.py
+++ b/src/collective/easyform/interfaces/mailer.py
@@ -129,7 +129,8 @@ class IMailer(IAction):
     )
     fieldset(u'message', label=PMF('Message'), fields=[
              'msg_subject', 'subject_field', 'body_pre', 'body_post',
-             'body_footer', 'showAll', 'showFields', 'includeEmpties'])
+             'body_footer', 'showAll', 'showFields', 'includeEmpties',
+             'sendCSV', ])
     directives.read_permission(msg_subject=MODIFY_PORTAL_CONTENT)
     msg_subject = zope.schema.TextLine(
         title=_(u'label_formmailer_subject', default=u'Subject'),
@@ -231,6 +232,18 @@ class IMailer(IAction):
         default=True,
         required=False,
     )
+
+    directives.read_permission(sendCSV=MODIFY_PORTAL_CONTENT)
+    sendCSV = zope.schema.Bool(
+        title=_(u'label_sendCSV_text', default=u'Send CSV data attachment'),
+        description=_(u'help_sendCSV_text', default=u''
+                      u'Check this to send a CSV file '
+                      u'attachment containing the values '
+                      u'filled out in the form.'),
+        default=False,
+        required=False,
+    )
+
     fieldset(u'template', label=PMF(
         'Template'), fields=['body_pt', 'body_type'])
     directives.write_permission(body_pt=config.EDIT_TALES_PERMISSION)


### PR DESCRIPTION
I added a new checkbox in the mailer adapter settings' Message tab: "Send CSV data attachment" "Check this to send a CSV file attachment containing the values filled out in the form"

If it's checked, the submitted form data (as selected by the "Include All Fields" and "Show Responses" fields) are attached to the email in CSV format, with proper escaping of the comma delimiter and quote character.