### PR TITLE
Fix filtered widgets in mailer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 2.0.0b8 (unreleased)
 --------------------
 
+New features:
+
+- New method in api: filter_widgets. If a isn't selected, mailer action don't try
+  to render its widget. This is useful when we want to avoid to show some widgets
+  like recaptcha, that could breaks if it's in the wrong context.
+  [cekk]
+
 Bug fixes:
 
 - changed the permission of saveddata action from "Manage portal" to "Modify portal content" so "action" and "view" have the same permission
@@ -39,9 +46,6 @@ New features:
 - add @@get_save_data_adapters view
   [tkimnguyen]
 
-- New method in api: filter_widgets. If a isn't selected, mailer action don't try
-  to render its widget. This is useful when we want to avoid to show some widgets
-  like recaptcha, that could breaks if it's in the wrong context.
 
 2.0.0b5 (2018-06-22)
 --------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,9 @@ New features:
 - add @@get_save_data_adapters view
   [tkimnguyen]
 
+- New method in api: filter_widgets. If a isn't selected, mailer action don't try
+  to render its widget. This is useful when we want to avoid to show some widgets
+  like recaptcha, that could breaks if it's in the wrong context.
 
 2.0.0b5 (2018-06-22)
 --------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-setuptools==33.1.1
-zc.buildout==2.9.5
+setuptools==38.7.0
+zc.buildout==2.11.5

--- a/src/collective/easyform/actions.py
+++ b/src/collective/easyform/actions.py
@@ -5,6 +5,7 @@ from BTrees.LOBTree import LOBTree as SavedDataBTree
 from collective.easyform import easyformMessageFactory as _
 from collective.easyform.api import dollar_replacer
 from collective.easyform.api import filter_fields
+from collective.easyform.api import filter_widgets
 from collective.easyform.api import format_addresses
 from collective.easyform.api import get_context
 from collective.easyform.api import get_expression
@@ -136,8 +137,7 @@ class Mailer(Action):
         form.schema = schema
         form.prefix = 'form'
         form._update()
-        widgets = {name: widget.render() for name, widget in form.w.items()}
-
+        widgets = filter_widgets(self, form.w)
         data = filter_fields(self, schema, unsorted_data)
 
         bodyfield = self.body_pt

--- a/src/collective/easyform/api.py
+++ b/src/collective/easyform/api.py
@@ -314,3 +314,20 @@ def filter_fields(context, schema, unsorted_data, omit=False):
         ret = OrderedDict([(f, data[f]) for f in fields])
 
     return ret
+
+
+def filter_widgets(context, widgets):
+    """Filter according to ``showAll`` and ``showFields``
+    settings to return proper widgets for result mailings,
+    thanks pages and the like.
+    """
+    filtered_widgets = {}
+    show_all = getattr(context, 'showAll', True)
+    show_fields = getattr(context, 'showFields', []) or []
+    for field_id, widget in widgets.items():
+        if not show_all:
+            if show_fields and field_id in show_fields:
+                filtered_widgets[field_id] = widget.render()
+        else:
+            filtered_widgets[field_id] = widget.render()
+    return filtered_widgets

--- a/src/collective/easyform/tests/testApi.py
+++ b/src/collective/easyform/tests/testApi.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+# Integeration tests specific to the mailer
+#
+
+from collective.easyform.actions import DummyFormView
+from collective.easyform.api import filter_widgets
+from collective.easyform.api import get_schema
+from collective.easyform.tests import base
+
+
+class TestFunctions(base.EasyFormTestCase):
+    """ Test mailer action """
+
+    def afterSetUp(self):
+        super(TestFunctions, self).afterSetUp()
+        self.folder.invokeFactory('EasyForm', 'ff1')
+        self.ff1 = getattr(self.folder, 'ff1')
+        self.dummy_form = DummyFormView(self.ff1, self.layer['request'])
+        self.dummy_form.schema = get_schema(self.ff1)
+        self.dummy_form.prefix = 'form'
+        self.dummy_form._update()
+
+    def test_selective_widgets(self):
+        """ Test selective inclusion of widgets for mail and thank you page """
+
+        self.assertEqual(
+            filter_widgets(self.ff1, self.dummy_form.w).keys(),
+            ['replyto', 'topic', 'comments']
+        )
+
+        self.ff1.showFields = ('topic', 'comments',)
+        self.assertEqual(
+            filter_widgets(self.ff1, self.dummy_form.w).keys(),
+            ['replyto', 'topic', 'comments']
+        )
+
+        self.ff1.showAll = False
+        self.assertEqual(
+            filter_widgets(self.ff1, self.dummy_form.w).keys(),
+            ['topic', 'comments']
+        )


### PR DESCRIPTION
The mailer action collects all available widgets and try to render them without some filtering.
Then, he filters the fields and get only the wanted fields.

When we use for example a captcha field, it will break when we try to render it, so i filtered also the widgets with only selected fields. In this case the mailer won't break.