### PR TITLE
Saveddata action permission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.0b6 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix permission for saveddata action form
+  [eikichi18]
 
 
 2.0.0b5 (2018-06-22)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 2.0.0b6 (unreleased)
 --------------------
 
-- Fix permission for saveddata action form
+Bug fixes:
+
+- changed the permission of saveddata action from "Manage portal" to "Modify portal content" so "action" and "view" have the same permission
   [eikichi18]
 
 

--- a/src/collective/easyform/configure.zcml
+++ b/src/collective/easyform/configure.zcml
@@ -79,6 +79,17 @@
         run_deps="false"
         />
   </genericsetup:upgradeSteps>
+  <genericsetup:upgradeSteps
+      source="1003"
+      destination="1004"
+      profile="collective.easyform:default">
+    <genericsetup:upgradeDepends
+        title="Changed permission of saveddata action"
+        import_profile="collective.easyform:default"
+        import_steps="actions"
+        run_deps="false"
+        />
+  </genericsetup:upgradeSteps>
 
   <utility
       factory=".setuphandlers.HiddenProfiles"

--- a/src/collective/easyform/profiles/default/actions.xml
+++ b/src/collective/easyform/profiles/default/actions.xml
@@ -37,7 +37,7 @@
    <property
       name="available_expr">python:object.portal_type == 'EasyForm'</property>
    <property name="permissions">
-    <element value="Manage portal"/>
+    <element value="Modify portal content"/>
    </property>
    <property name="visible">True</property>
   </object>

--- a/src/collective/easyform/profiles/default/metadata.xml
+++ b/src/collective/easyform/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1003</version>
+  <version>1004</version>
 </metadata>


### PR DESCRIPTION
Changed the permissions of the saveddata action.
Now the permissions of the action correspond to the permissions of the corresponding view.