### PR TITLE
retain 5.0.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ addons:
 matrix:
   include:
     - python: "2.7"
+      env: PLONE_VERSION=5.0.x
+    - python: "2.7"
       env: PLONE_VERSION=5.1.x
     - python: "2.7"
       env: PLONE_VERSION=5.2.x

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'Environment :: Web Environment',
         'Framework :: Plone',
         'Framework :: Plone :: Addon',
+        'Framework :: Plone :: 5.0',
         'Framework :: Plone :: 5.1',
         'Framework :: Plone :: 5.2',
         'Programming Language :: Python',

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -50,7 +50,6 @@ except ImportError:
             value = value.encode(encoding)
         return value
 
-
     safe_encode = safe_bytes
 
 

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -20,7 +20,6 @@ from plone.namedfile.interfaces import INamed
 from plone.z3cform import layout
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.CMFPlone.utils import safe_encode
 from z3c.form import button
 from z3c.form import form
 from z3c.form.interfaces import DISPLAY_MODE
@@ -36,8 +35,23 @@ from ZPublisher.mapply import mapply
 
 import six
 
+
 logger = getLogger('collective.easyform')
 PMF = MessageFactory('plone')
+
+try:
+    from Products.CMFPlone.utils import safe_encode
+except ImportError:
+    # only thing needed to maintain 5.0.x compatibility
+    def safe_bytes(value, encoding='utf-8'):
+        """Convert text to bytes of the specified encoding.
+        """
+        if isinstance(value, six.text_type):
+            value = value.encode(encoding)
+        return value
+
+
+    safe_encode = safe_bytes
 
 
 @implementer(IEasyFormForm)

--- a/tests-5.0.x.cfg
+++ b/tests-5.0.x.cfg
@@ -1,0 +1,22 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.0.x.cfg
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+    https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
+    base.cfg
+
+parts +=
+    test
+    code-analysis
+    createcoverage
+
+package-name = collective.easyform
+package-extras = [test]
+test-eggs =
+
+[versions]
+setuptools =
+zc.buildout =
+coverage = >=3.7
+plone.app.mosaic =
+plone.app.robotframework = 1.5.0


### PR DESCRIPTION
Please consider that 5.0.x is not that old and people have a lot of existing hosting based on it. Where its just a couple of lines to retain compatibility and the plugin itself is still buggy please can we make this small effort to keep it compatible until it is really is a good reason to stop support? 