### PR TITLE
Let filter_fields return fields in the correct order. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,13 @@ Changelog
 ------------------
 
 NOTE: if you deploy 2.1.1+, the easyform extended validations start working again on fields
-in extra field sets (they only worked on the main/default fields). This could cause some 
-issues if those validators, or default values, were misconfigured in the first place. 
+in extra field sets (they only worked on the main/default fields). This could cause some
+issues if those validators, or default values, were misconfigured in the first place.
+
+- Let ``filter_fields`` return fields in the correct order.
+  This fixes the order on the default mailer template.
+  Part of `issue #163 <https://github.com/collective/collective.easyform/issues/163>`_.
+  [maurits]
 
 - Fixed validation, inline validation, and defaults for fields in fieldsets.
   Refs issues `#172 <https://github.com/collective/collective.easyform/issues/172>`_

--- a/src/collective/easyform/api.py
+++ b/src/collective/easyform/api.py
@@ -303,7 +303,18 @@ def filter_fields(context, schema, unsorted_data, omit=False):
 
     if not getattr(context, "showAll", True):
         showFields = getattr(context, "showFields", []) or []
-        fields = [f for f in fields if f in showFields]
+        # Only show fields from 'showFields', and also keep the order,
+        # even when that is not always needed or used by code that calls us.
+        # Note that showFields may contain fields that are not in the schema
+        # or the data: the schema may be limited to one fieldset.
+        ordered_fields = []
+        for fieldname in showFields:
+            for f in fields:
+                if f == fieldname:
+                    ordered_fields.append(f)
+                    fields.remove(f)
+                    break
+        fields = ordered_fields
 
     if not getattr(context, "includeEmpties", True):
         fields = [f for f in fields if data[f]]

--- a/src/collective/easyform/tests/testApi.py
+++ b/src/collective/easyform/tests/testApi.py
@@ -4,6 +4,7 @@
 #
 
 from collective.easyform.actions import DummyFormView
+from collective.easyform.api import filter_fields
 from collective.easyform.api import filter_widgets
 from collective.easyform.api import get_schema
 from collective.easyform.tests import base
@@ -22,7 +23,12 @@ class TestFunctions(base.EasyFormTestCase):
         self.dummy_form._update()
 
     def test_selective_widgets(self):
-        """ Test selective inclusion of widgets for mail and thank you page """
+        """ Test selective inclusion of widgets for mail and thank you page.
+
+        This uses filter_widgets, which needs as input:
+        - a context (the form or a mailer)
+        - a list of widgets
+        """
 
         self.assertEqual(
             list(filter_widgets(self.ff1, self.dummy_form.w).keys()),
@@ -39,4 +45,108 @@ class TestFunctions(base.EasyFormTestCase):
         self.assertEqual(
             list(filter_widgets(self.ff1, self.dummy_form.w).keys()),
             ["topic", "comments"],
+        )
+
+    def test_selective_fields(self):
+        """ Test selective inclusion of fields for mail and thank you page.
+
+        This uses filter_fields, which needs as input:
+        - a context (the form or a mailer)
+        - a list of widgets
+        - (unsorted) data (user input from the request)
+        - optional omit=True/False (default False)
+
+        With omit=True, we get a list of field names to omit.
+        With omit=False, we get an ordered dict of fields to include.
+        """
+        # Test the types of answers.
+        from collections import OrderedDict as BaseDict
+        from collective.easyform.api import OrderedDict
+        self.assertIsInstance(filter_fields(self.ff1, self.dummy_form.schema, {}), OrderedDict)
+        self.assertIsInstance(filter_fields(self.ff1, self.dummy_form.schema, {}), BaseDict)
+        self.assertIsInstance(filter_fields(self.ff1, self.dummy_form.schema, {}), dict)
+        self.assertIsInstance(filter_fields(self.ff1, self.dummy_form.schema, {}, omit=True), list)
+
+        # Empty data
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, {}).keys()),
+            [],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, {}, omit=True)),
+            [],
+        )
+
+        # All data empty
+        data = {"replyto": "", "topic": "", "comments": ""}
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).keys()),
+            ["replyto", "topic", "comments"],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).values()),
+            ["", "", ""],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data, omit=True)),
+            [],
+        )
+        self.ff1.includeEmpties = False
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).keys()),
+            [],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data, omit=True)),
+            ["replyto", "topic", "comments"],
+        )
+
+        # All data filled in
+        data = {"replyto": "me@example.org", "topic": "Test", "comments": "Ni"}
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).keys()),
+            ["replyto", "topic", "comments"],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).values()),
+            ["me@example.org", "Test", "Ni"],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data, omit=True)),
+            [],
+        )
+
+        # Show only specific fields, not active when showAll=True.
+        self.ff1.showFields = ("no-such-field", "topic", "comments")
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).keys()),
+            ["replyto", "topic", "comments"],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data, omit=True)),
+            [],
+        )
+
+        # Only show specific fields.
+        self.ff1.showAll = False
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).keys()),
+            ["topic", "comments"],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data, omit=True)),
+            ["replyto"],
+        )
+
+        # The order of showFields is kept.
+        # Note: currently the order is used on the mail template,
+        # but not on the thanks page.
+        self.ff1.showFields = ("comments", "no-such-field", "topic")
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data).keys()),
+            ["comments", "topic"],
+        )
+        self.assertEqual(
+            list(filter_fields(self.ff1, self.dummy_form.schema, data, omit=True)),
+            ["replyto"],
         )


### PR DESCRIPTION
This fixes the order on the default mailer template. This solves one part of issue #163 on master.
(Letting the thanks page use the correct order is trickier, and I am not going to try that now.)

This PR also adds tests for the `filter_fields` api function.