### PR TITLE
Fixed headerinjection by adding a macro. [1.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ New:
 
 Fixes:
 
+- Fixed errors with ``header_injection`` implementation. [maurits]
+
 - Add missing ``header_injection`` implementation. Backport for 1.x from #152. [krissik, fredvd]
 
 - Fixed filtering of fields on thanks page and mailer template.

--- a/collective/easyform/browser/easyform_layout.pt
+++ b/collective/easyform/browser/easyform_layout.pt
@@ -11,8 +11,10 @@
      </metal:javascript_head>
 
     <metal:main fill-slot="main">
-        <metal:headerinjection-slot define-slot="headerinjection">
-         </metal:headerinjection-slot>
+        <metal:headerinjection define-macro="headerinjection">
+            <metal:headerinjection-slot define-slot="headerinjection">
+            </metal:headerinjection-slot>
+        </metal:headerinjection>
         <metal:main-macro define-macro="main">
             <h1 class="documentFirstHeading" tal:content="view/label">Title</h1>
             <div id="content-core" tal:content="structure view/contents" />

--- a/collective/easyform/browser/view.py
+++ b/collective/easyform/browser/view.py
@@ -283,6 +283,8 @@ class EasyFormForm(AutoExtensibleForm, form.Form):
 
     def header_injection(self):
         tal_expression = self.context.headerInjection
+        if not tal_expression:
+            return ''
         header_to_inject = get_expression(self.context, tal_expression)
         if  isinstance(header_to_inject, unicode):
             header_to_inject = header_to_inject.encode('utf-8')


### PR DESCRIPTION
Needed on Plone 4, not on Plone 5.
See https://github.com/collective/collective.easyform/pull/167#issuecomment-495149499

Also fixed error when headerInjection field is None, which is the case for existing forms.