### PR TITLE
Add collective.z3cform.norobots integration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ issues if those validators, or default values, were misconfigured in the first p
 - Avoid potential CannotGetPortalError on startup #164
   [laulaz]
 
+- Add collective.z3cform.norobots integration #145
+  [1letter/gomez]
+
 
 2.1.0 (2019-04-25)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,43 @@ As last step you might want to not include the recaptcha field in the thanks pag
 To do that, edit the form, go to the "Thanks page" settings, disable "Show all fields" and then include only those you want.
 Likewise for the mailing: Open the form actions via the actions toolbar menu and edit the mailer settings accordingly.
 
+
+collective.z3cform.norobots support
+===================================
+
+Install ``collective.easyform`` with the  ``norobots`` extra:
+
+.. code-block:: shell
+
+    [buildout]
+
+    ...
+
+    eggs =
+        collective.easyform [norobots]
+
+
+And run buildout and install EasyForm as described above.
+
+Then go to the EasyFrom controlpanel (``/@@easyform-controlpanel``) and add the "NorobotCaptcha" field to "Allowed Fields".
+Alternatively, activate it by adding it as an ``registry.xml`` entry for Generic Setup:
+
+.. code-block:: xml
+
+    <record name="easyform.allowedFields">
+      <value purge="False">
+        <element>collective.easyform.fields.NorobotCaptcha</element>
+      </value>
+    </record>
+
+Then add the NorobotCaptcha field to the forms where you want to use it.
+As field type use ``NorobotCaptcha`` and set ``require`` to false.
+
+As last step you might want to not include the norobotcaptcha field in the thanks page and mailer action.
+To do that, edit the form, go to the "Thanks page" settings, disable "Show all fields" and then include only those you want.
+Likewise for the mailing: Open the form actions via the actions toolbar menu and edit the mailer settings accordingly.
+
+
 Actions
 =======
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,9 @@ setup(
         'recaptcha': [
             'plone.formwidget.recaptcha'
         ],
+        'norobots': [
+            'collective.z3cform.norobots'
+        ],
         'test': [
             'plone.app.testing[robot]',
             'plone.app.robotframework',

--- a/src/collective/easyform/browser/fields.zcml
+++ b/src/collective/easyform/browser/fields.zcml
@@ -78,4 +78,26 @@
             permission="cmf.ModifyPortalContent"
             />
     </configure>
+    <configure
+        zcml:condition="installed collective.z3cform.norobots">
+        <utility
+            name="collective.easyform.fields.NorobotCaptcha"
+            component=".fields.NorobotFactory"
+            />
+        <utility
+            name="collective.easyform.fields.NorobotCaptcha"
+            component=".fields.NorobotCaptchaHandler"
+            />
+        <adapter
+            for="
+            collective.easyform.interfaces.IEasyForm
+            *
+            collective.easyform.interfaces.IEasyFormForm
+            collective.easyform.interfaces.INorobotCaptcha
+            *
+            "
+            provides="z3c.form.interfaces.IValidator"
+            factory="collective.z3cform.norobots.validator.NorobotsValidator"
+            />
+    </configure>
 </configure>

--- a/src/collective/easyform/browser/fields.zcml
+++ b/src/collective/easyform/browser/fields.zcml
@@ -82,11 +82,11 @@
         zcml:condition="installed collective.z3cform.norobots">
         <utility
             name="collective.easyform.fields.NorobotCaptcha"
-            component=".fields.NorobotFactory"
+            component="..fields.NorobotFactory"
             />
         <utility
             name="collective.easyform.fields.NorobotCaptcha"
-            component=".fields.NorobotCaptchaHandler"
+            component="..fields.NorobotCaptchaHandler"
             />
         <adapter
             for="

--- a/src/collective/easyform/browser/widgets.zcml
+++ b/src/collective/easyform/browser/widgets.zcml
@@ -93,4 +93,19 @@
              *"
         />
     </configure>
+    <configure
+        zcml:condition="installed collective.z3cform.norobots">
+        <adapter
+            factory="collective.z3cform.norobots.widget.NorobotsFieldWidget"
+            provides="z3c.form.interfaces.IFieldWidget"
+            for="collective.easyform.interfaces.INorobotCaptcha
+                *"
+            />
+        <z3c:widgetTemplate
+            layer="..interfaces.IEasyFormLayer"
+            mode="display"
+            template="empty.pt"
+            widget="collective.z3cform.norobots.widget.INorobotsWidget" />
+
+    </configure>
 </configure>

--- a/src/collective/easyform/fields.py
+++ b/src/collective/easyform/fields.py
@@ -6,6 +6,7 @@ from collective.easyform.interfaces import IEasyFormForm
 from collective.easyform.interfaces import IFieldExtender
 from collective.easyform.interfaces import ILabel
 from collective.easyform.interfaces import IReCaptcha
+from collective.easyform.interfaces import INorobotCaptcha
 from collective.easyform.interfaces import IRichLabel
 from collective.easyform.validators import IFieldValidator
 from plone.schemaeditor.fields import FieldFactory
@@ -141,3 +142,17 @@ ReCaptchaFactory = FieldFactory(
     ReCaptcha, _(u"label_recaptcha_field", default=u"ReCaptcha")
 )
 ReCaptchaHandler = BaseHandler(ReCaptcha)
+
+
+@implementer(INorobotCaptcha)
+class NorobotCaptcha(TextLine):
+
+    """A NorobotCaptcha field
+    """
+
+
+NorobotFactory = FieldFactory(
+    NorobotCaptcha,
+    _(u'label_norobot_field', default=u'NorobotCaptcha')
+)
+NorobotCaptchaHandler = BaseHandler(NorobotCaptcha)

--- a/src/collective/easyform/interfaces/__init__.py
+++ b/src/collective/easyform/interfaces/__init__.py
@@ -20,6 +20,7 @@ from .fields import IFieldValidator  # noqa
 from .fields import ILabel  # noqa
 from .fields import ILabelWidget  # noqa
 from .fields import IReCaptcha  # noqa
+from .fields import INorobotCaptcha  # noqa
 from .fields import IRichLabel  # noqa
 from .fields import IRichLabelWidget  # noqa
 from .layer import IEasyFormLayer  # noqa

--- a/src/collective/easyform/interfaces/fields.py
+++ b/src/collective/easyform/interfaces/fields.py
@@ -190,6 +190,11 @@ class IReCaptcha(zope.schema.interfaces.ITextLine):
     """ReCaptcha Field."""
 
 
+class INorobotCaptcha(zope.schema.interfaces.ITextLine):
+
+    """Norobot Field."""
+
+
 class IFieldValidator(Interface):
 
     """Base marker for field validators"""

--- a/src/collective/easyform/tests/base.py
+++ b/src/collective/easyform/tests/base.py
@@ -40,6 +40,11 @@ class Fixture(PloneSandboxLayer):
             self.loadZCML(package=plone.formwidget.recaptcha)
         except ImportError:
             pass
+        try:
+            import collective.z3cform.norobots
+            self.loadZCML(package=collective.z3cform.norobots)
+        except ImportError:
+            pass
 
         # set default publisher encoding for Plone 5.1
         # this is set in zope.conf via plone.recipe.zope2instance but for


### PR DESCRIPTION
Back from the graveyard, thanks to @1letter!
Based on https://github.com/collective/collective.easyform/pull/148, just a rebase and small fix.

Works on Plone 5.2 and Python 3. Needs collective.z3cform.norobots master checkout.

Fixes #145