### PR TITLE
fix validators for None

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Changelog
 - Format code according to Plone standards: black, isort, zpretty.
   [thet]
 
+- Fix Validators for value None: return valid and let required handle it
+  [Nimo-19]
+
 
 2.1.5 (2020-02-09)
 ------------------

--- a/src/collective/easyform/tests/testValidators.py
+++ b/src/collective/easyform/tests/testValidators.py
@@ -84,6 +84,41 @@ class TestBaseValidators(base.EasyFormTestCase):
         data, errors = form.extractData()
         self.assertEqual(len(errors), 1)
 
+    # Test value None and not required
+    def test_basevalidator3(self):
+
+        request = self.layer["request"]
+        request.form["form.widgets.replyto"] = None
+
+        fields = get_schema(self.ff1)
+
+        fields["replyto"].required = False
+        IFieldExtender(fields["replyto"]).validators = ["isEmail"]
+        set_fields(self.ff1, fields)
+        view = self.ff1.restrictedTraverse("view")
+        form = view.form_instance
+        form.update()
+
+        data, errors = form.extractData()
+        self.assertEqual(errors, ())
+
+    # Test value None and required
+    def test_basevalidator4(self):
+
+        request = self.layer["request"]
+        request.form["form.widgets.replyto"] = None
+
+        fields = get_schema(self.ff1)
+
+        IFieldExtender(fields["replyto"]).validators = ["isEmail"]
+        set_fields(self.ff1, fields)
+        view = self.ff1.restrictedTraverse("view")
+        form = view.form_instance
+        form.update()
+
+        data, errors = form.extractData()
+        self.assertEqual(len(errors), 1)
+
     def test_talvalidator(self):
         fields = get_schema(self.ff1)
         IFieldExtender(fields["comments"]).TValidator = "python: value == 'comments'"
@@ -255,12 +290,14 @@ class TestCustomValidators(base.EasyFormTestCase):
         v = getUtility(IFieldValidator, name="isValidEmail")
         self.assertEqual(v("hi@there.com"), None)
         self.assertEqual(v("one@u.washington.edu"), None)
+        self.assertEqual(v(None), None)
         self.assertRaises(EmailAddressInvalid, v, "@there.com")
 
     def test_isCommaSeparatedEmails(self):
         v = getUtility(IFieldValidator, name="isCommaSeparatedEmails")
         self.assertEqual(v("hi@there.com,another@two.com"), None)
         self.assertEqual(v("one@u.washington.edu,  two@u.washington.edu"), None)
+        self.assertEqual(v(None), None)
         self.assertNotEqual(v("abc@plone.org; xyz@plone.org"), None)
 
 

--- a/src/collective/easyform/validators.py
+++ b/src/collective/easyform/validators.py
@@ -14,6 +14,8 @@ BAD_SIGNS = frozenset(["<a ", "www.", "http:", ".com", "https:"])
 
 
 def isValidEmail(value):
+    if value is None:
+        return
     """Check for the user email address"""
     reg_tool = api.portal.get_tool("portal_registration")
     if not (value and reg_tool.isValidEmail(value)):
@@ -21,6 +23,9 @@ def isValidEmail(value):
 
 
 def isCommaSeparatedEmails(value):
+    if value is None:
+        # Let the system for required take care of None values
+        return
     """Check for one or more E-Mail Addresses separated by commas"""
     reg_tool = api.portal.get_tool("portal_registration")
     for v in value.split(","):
@@ -59,6 +64,9 @@ def update_validators():
 
         def method(name):
             def validate(value):
+                if value is None:
+                    # Let the system for required take care of None values
+                    return
                 if six.PY2 and isinstance(value, six.text_type):
                     value = value.encode("utf-8")
                 res = validation(name, value)


### PR DESCRIPTION
In Relation to the issue #209.
Something similar happened on our instance using the isCommaSperatedEmail Field #202 
Today I think I found and fixed the problem.
Simply return if the value of the field is None.
If the field is set to be required the Required will take care of None Values.