### PR TITLE
Hide description field from form actions.

### DIFF
--- a/news/224.feature
+++ b/news/224.feature
@@ -1,0 +1,1 @@
+Use profile to configure roles instead of ZCML for easier customization.

--- a/news/225.bugfix
+++ b/news/225.bugfix
@@ -1,0 +1,1 @@
+Make Actions better compatible with plone.supermodel/autoform directives.

--- a/news/226.breaking
+++ b/news/226.breaking
@@ -1,0 +1,2 @@
+Hide the "description" field from form actions, as it is not used anywhere.
+Customizations which try to omit or use the description field might need adaptions.

--- a/src/collective/easyform/browser/actions.py
+++ b/src/collective/easyform/browser/actions.py
@@ -244,8 +244,8 @@ class EasyFormActionsListingPage(SchemaListingPage):
 
 
 class ActionAddForm(FieldAddForm):
-
-    fields = field.Fields(INewAction)
+    schema = INewAction
+    fields = field.Fields()  # let fields be updated by AutoExtensibleForm.updateFields
     label = _("Add new action")
 
 

--- a/src/collective/easyform/interfaces/actions.py
+++ b/src/collective/easyform/interfaces/actions.py
@@ -9,7 +9,6 @@ from plone.schemaeditor.interfaces import IFieldEditorExtender
 from plone.schemaeditor.interfaces import ISchemaContext
 from plone.supermodel.directives import fieldset
 from plone.supermodel.model import Schema
-from zope.interface import Interface
 
 import z3c.form.interfaces
 import zope.interface
@@ -37,7 +36,7 @@ def isValidFieldName(value):
     return True
 
 
-class INewAction(Interface):
+class INewAction(Schema):
 
     title = zope.schema.TextLine(title=__(u"Title"), required=True)
 

--- a/src/collective/easyform/interfaces/actions.py
+++ b/src/collective/easyform/interfaces/actions.py
@@ -47,18 +47,12 @@ class INewAction(Schema):
         constraint=isValidFieldName,
     )
 
-    description = zope.schema.Text(
-        title=__(u"Help Text"),
-        description=__(u"Shows up in the form as help text for the field."),
-        required=False,
-    )
-
     factory = zope.schema.Choice(
         title=_(u"Action type"), vocabulary="EasyFormActions", required=True
     )
 
     @zope.interface.invariant
-    def checkTitleAndDescriptionTypes(data):  # NOQA
+    def checkTitleTypes(data):
         if data.__name__ is not None and data.factory is not None:
             if (
                 data.__name__ == "title"
@@ -66,13 +60,6 @@ class INewAction(Schema):
             ):
                 raise zope.interface.Invalid(
                     __(u"The 'title' field must be a Text line (string) " u"field.")
-                )
-            if (
-                data.__name__ == "description"
-                and data.factory.fieldcls is not zope.schema.Text
-            ):
-                raise zope.interface.Invalid(
-                    __(u"The 'description' field must be a Text field.")
                 )
 
 
@@ -117,7 +104,9 @@ class IActionEditForm(z3c.form.interfaces.IEditForm):
 
 
 class IAction(Schema, zope.schema.interfaces.IField):
-    directives.omitted("required", "order", "default", "missing_value", "readonly")
+    directives.omitted(
+        "description", "required", "order", "default", "missing_value", "readonly"
+    )
     #     required = zope.schema.Bool(
     #         title=_('Enabled'),
     #        description=_('Tells whether a action is enabled.'),

--- a/src/collective/easyform/permissions.zcml
+++ b/src/collective/easyform/permissions.zcml
@@ -2,73 +2,41 @@
   <permission
       id="collective.easyform.AddContent"
       title="collective.easyform: Add Content"
-      >
-    <role name="Manager" />
-    <role name="Owner" />
-    <role name="Contributor" />
-    <role name="Site Administrator" />
-  </permission>
+      />
   <permission
       id="collective.easyform.AddMailers"
       title="collective.easyform: Add Mailers"
-      >
-    <role name="Manager" />
-    <role name="Owner" />
-    <role name="Site Administrator" />
-  </permission>
+      />
   <permission
       id="collective.easyform.AddDataSavers"
       title="collective.easyform: Add Data Savers"
-      >
-    <role name="Manager" />
-    <role name="Owner" />
-    <role name="Site Administrator" />
-  </permission>
+      />
   <permission
       id="collective.easyform.AddCustomScripts"
       title="collective.easyform: Add Custom Scripts"
-      >
-    <role name="Manager" />
-  </permission>
+      />
   <permission
       id="collective.easyform.EditTALESFields"
       title="collective.easyform: Edit TALES Fields"
-      >
-    <role name="Manager" />
-  </permission>
+      />
   <permission
       id="collective.easyform.EditPythonFields"
       title="collective.easyform: Edit Python Fields"
-      >
-    <role name="Manager" />
-  </permission>
+      />
   <permission
       id="collective.easyform.EditAdvancedFields"
       title="collective.easyform: Edit Advanced Fields"
-      >
-    <role name="Manager" />
-    <role name="Site Administrator" />
-  </permission>
+      />
   <permission
       id="collective.easyform.EditMailAddresses"
       title="collective.easyform: Edit Mail Addresses"
-      >
-    <role name="Manager" />
-    <role name="Owner" />
-    <role name="Site Administrator" />
-  </permission>
+      />
   <permission
       id="collective.easyform.EditEncryptionSpecs"
       title="collective.easyform: Edit Encryption Specs"
-      >
-    <role name="Manager" />
-  </permission>
+      />
   <permission
       id="collective.easyform.DownloadSavedInput"
       title="collective.easyform: Download Saved Input"
-      >
-    <role name="Manager" />
-    <role name="Owner" />
-    <role name="Site Administrator" />
-  </permission>
+      />
 </configure>

--- a/src/collective/easyform/profiles/default/metadata.xml
+++ b/src/collective/easyform/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1005</version>
+  <version>1006</version>
 </metadata>

--- a/src/collective/easyform/profiles/default/rolemap.xml
+++ b/src/collective/easyform/profiles/default/rolemap.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission acquire="True"
+                name="collective.easyform: Add Content"
+    >
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Contributor" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Add Mailers"
+    >
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Add Data Savers"
+    >
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Add Custom Scripts"
+    >
+      <role name="Manager" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Edit TALES Fields"
+    >
+      <role name="Manager" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Edit Python Fields"
+    >
+      <role name="Manager" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Edit Advanced Fields"
+    >
+      <role name="Manager" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Edit Mail Addresses"
+    >
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Edit Encryption Specs"
+    >
+      <role name="Manager" />
+    </permission>
+    <permission acquire="True"
+                name="collective.easyform: Download Saved Input"
+    >
+      <role name="Manager" />
+      <role name="Owner" />
+      <role name="Site Administrator" />
+    </permission>
+  </permissions>
+</rolemap>

--- a/src/collective/easyform/upgrades/1006.zcml
+++ b/src/collective/easyform/upgrades/1006.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    >
+
+  <gs:upgradeSteps
+      destination="1006"
+      profile="collective.easyform:default"
+      source="1005"
+      >
+    <gs:upgradeDepends
+        title="Import rolemap"
+        import_profile="collective.easyform:default"
+        import_steps="rolemap"
+        run_deps="false"
+        />
+  </gs:upgradeSteps>
+
+</configure>

--- a/src/collective/easyform/upgrades/configure.zcml
+++ b/src/collective/easyform/upgrades/configure.zcml
@@ -4,4 +4,5 @@
   <include file="1003.zcml" />
   <include file="1004.zcml" />
   <include file="1005.zcml" />
+  <include file="1006.zcml" />
 </configure>


### PR DESCRIPTION
Hide the "description" field from form actions, as it is not used anywhere.
Customizations which try to omit or use the description field might need adaptions.