### PR TITLE
Change semantics for the "advanced" permission and introduce new "technical" permission.

### DIFF
--- a/news/229.breaking
+++ b/news/229.breaking
@@ -1,0 +1,20 @@
+Change semantics for the "advanced" permission and introduce new "technical" permission.
+To better support use cases for "power users" while not overloading them with complex fields where a technical understanding is necessary the permissions are changed as follows:
+
+"Edit Advanced Fields":
+- IEasyForm.submitLabel
+- IEasyForm.useCancelButton
+- IEasyForm.resetLabel
+- IEasyForm.form_tabbing
+- IEasyForm.default_fieldset_label
+- IFieldExtender.field_widget
+- IFieldExtender.validators
+
+"Edit Technical Fields":
+- IEasyForm.method
+- IEasyForm.unload_protection
+- IEasyForm.CSRFProtection
+- IEasyForm.forceSSL
+- IMailer.replyto_field
+- IMailer.xinfo_headers
+- IMailer.additional_headers

--- a/src/collective/easyform/config.py
+++ b/src/collective/easyform/config.py
@@ -9,6 +9,7 @@ this_path = os.path.dirname(__file__)
 
 EDIT_TALES_PERMISSION = "collective.easyform.EditTALESFields"
 EDIT_PYTHON_PERMISSION = "collective.easyform.EditPythonFields"
+EDIT_TECHNICAL_PERMISSION = "collective.easyform.EditTechnicalFields"
 EDIT_ADVANCED_PERMISSION = "collective.easyform.EditAdvancedFields"
 EDIT_ADDRESSING_PERMISSION = "collective.easyform.EditMailAddresses"
 USE_ENCRYPTION_PERMISSION = "collective.easyform.EditEncryptionSpecs"

--- a/src/collective/easyform/interfaces/easyform.py
+++ b/src/collective/easyform/interfaces/easyform.py
@@ -196,30 +196,35 @@ class IEasyForm(Schema):
         ],
         order=20,
     )
+    directives.write_permission(submitLabel=config.EDIT_ADVANCED_PERMISSION)
     submitLabel = zope.schema.TextLine(
         title=_(u"label_submitlabel_text", default=u"Submit Button Label"),
         description=_(u"help_submitlabel_text", default=u""),
         defaultFactory=default_submitLabel,
         required=False,
     )
+    directives.write_permission(useCancelButton=config.EDIT_ADVANCED_PERMISSION)
     useCancelButton = zope.schema.Bool(
         title=_(u"label_showcancel_text", default=u"Show Reset Button"),
         description=_(u"help_showcancel_text", default=u""),
         default=False,
         required=False,
     )
+    directives.write_permission(resetLabel=config.EDIT_ADVANCED_PERMISSION)
     resetLabel = zope.schema.TextLine(
         title=_(u"label_reset_button", default=u"Reset Button Label"),
         description=_(u"help_reset_button", default=u""),
         defaultFactory=default_resetLabel,
         required=False,
     )
+    directives.write_permission(form_tabbing=config.EDIT_ADVANCED_PERMISSION)
     form_tabbing = zope.schema.Bool(
         title=_(u"label_form_tabbing", default=u"Turn fieldsets to tabs"),
         description=_(u"help_form_tabbing", default=u""),
         default=True,
         required=False,
     )
+    directives.write_permission(default_fieldset_label=config.EDIT_ADVANCED_PERMISSION)
     default_fieldset_label = zope.schema.TextLine(
         title=_(
             u"label_default_fieldset_label_text",
@@ -232,6 +237,7 @@ class IEasyForm(Schema):
         required=False,
         default=u"",
     )
+    directives.write_permission(method=config.EDIT_TECHNICAL_PERMISSION)
     method = zope.schema.Choice(
         title=_(u"label_method", default=u"Form method"),
         description=_(u"help_method", default=u""),
@@ -239,12 +245,14 @@ class IEasyForm(Schema):
         required=False,
         vocabulary="easyform.FormMethods",
     )
+    directives.write_permission(unload_protection=config.EDIT_TECHNICAL_PERMISSION)
     unload_protection = zope.schema.Bool(
         title=_(u"label_unload_protection", default=u"Unload protection"),
         description=_(u"help_unload_protection", default=u""),
         default=True,
         required=False,
     )
+    directives.write_permission(CSRFProtection=config.EDIT_TECHNICAL_PERMISSION)
     CSRFProtection = zope.schema.Bool(
         title=_(u"label_csrf", default=u"CSRF Protection"),
         description=_(
@@ -256,7 +264,7 @@ class IEasyForm(Schema):
         default=True,
         required=False,
     )
-    directives.write_permission(forceSSL=config.EDIT_ADVANCED_PERMISSION)
+    directives.write_permission(forceSSL=config.EDIT_TECHNICAL_PERMISSION)
     forceSSL = zope.schema.Bool(
         title=_(u"label_force_ssl", default=u"Force SSL connection"),
         description=_(

--- a/src/collective/easyform/interfaces/fields.py
+++ b/src/collective/easyform/interfaces/fields.py
@@ -55,11 +55,28 @@ class IEasyFormFieldsEditorExtender(IFieldEditorExtender):
 
 
 class IFieldExtender(Schema):
+    fieldset(
+        u"advanced",
+        label=_("Advanced"),
+        fields=["field_widget", "validators", "THidden"],
+    )
+    directives.write_permission(field_widget=config.EDIT_ADVANCED_PERMISSION)
     field_widget = zope.schema.Choice(
         title=_(u"label_field_widget", default=u"Field Widget"),
         description=_(u"help_field_widget", default=u""),
         required=False,
         source=widgetsFactory,
+    )
+    directives.write_permission(validators=config.EDIT_ADVANCED_PERMISSION)
+    validators = zope.schema.List(
+        title=_("Validators"),
+        description=_(
+            u"help_userfield_validators",
+            default=u"Select the validators to use on this field",
+        ),
+        unique=True,
+        required=False,
+        value_type=zope.schema.Choice(vocabulary="easyform.Validators"),
     )
     directives.write_permission(THidden=config.EDIT_TALES_PERMISSION)
     THidden = zope.schema.Bool(
@@ -136,16 +153,6 @@ class IFieldExtender(Schema):
         ),
         default=False,
         required=False,
-    )
-    validators = zope.schema.List(
-        title=_("Validators"),
-        description=_(
-            u"help_userfield_validators",
-            default=u"Select the validators to use on this field",
-        ),
-        unique=True,
-        required=False,
-        value_type=zope.schema.Choice(vocabulary="easyform.Validators"),
     )
 
 

--- a/src/collective/easyform/interfaces/mailer.py
+++ b/src/collective/easyform/interfaces/mailer.py
@@ -116,7 +116,7 @@ class IMailer(IAction):
         required=False,
     )
 
-    directives.write_permission(replyto_field=config.EDIT_ADVANCED_PERMISSION)
+    directives.write_permission(replyto_field=config.EDIT_TECHNICAL_PERMISSION)
     directives.read_permission(replyto_field=MODIFY_PORTAL_CONTENT)
     replyto_field = zope.schema.Choice(
         title=_(u"label_formmailer_replyto_extract", default=u"Extract Reply-To From"),
@@ -325,7 +325,7 @@ class IMailer(IAction):
         u"headers", label=_("Headers"), fields=["xinfo_headers", "additional_headers"]
     )
     directives.widget(xinfo_headers=CheckBoxFieldWidget)
-    directives.write_permission(xinfo_headers=config.EDIT_ADVANCED_PERMISSION)
+    directives.write_permission(xinfo_headers=config.EDIT_TECHNICAL_PERMISSION)
     directives.read_permission(xinfo_headers=MODIFY_PORTAL_CONTENT)
     xinfo_headers = zope.schema.List(
         title=_(u"label_xinfo_headers_text", default=u"HTTP Headers"),
@@ -341,7 +341,7 @@ class IMailer(IAction):
         missing_value=[u"HTTP_X_FORWARDED_FOR", u"REMOTE_ADDR", u"PATH_INFO"],
         value_type=zope.schema.Choice(vocabulary="easyform.XinfoHeaders"),
     )
-    directives.write_permission(additional_headers=config.EDIT_ADVANCED_PERMISSION)
+    directives.write_permission(additional_headers=config.EDIT_TECHNICAL_PERMISSION)
     directives.read_permission(additional_headers=MODIFY_PORTAL_CONTENT)
     additional_headers = zope.schema.List(
         title=_(u"label_formmailer_additional_headers", default=u"Additional Headers"),

--- a/src/collective/easyform/permissions.zcml
+++ b/src/collective/easyform/permissions.zcml
@@ -23,6 +23,10 @@
       id="collective.easyform.EditPythonFields"
       title="collective.easyform: Edit Python Fields"
       />
+  <permission 
+      id="collective.easyform.EditTechnicalFields"
+      title="collective.easyform: Edit Technical Fields"
+      />
   <permission
       id="collective.easyform.EditAdvancedFields"
       title="collective.easyform: Edit Advanced Fields"

--- a/src/collective/easyform/profiles/default/rolemap.xml
+++ b/src/collective/easyform/profiles/default/rolemap.xml
@@ -39,9 +39,16 @@
       <role name="Manager" />
     </permission>
     <permission acquire="True"
+                name="collective.easyform: Edit Technical Fields"
+    >
+      <role name="Manager" />
+      <role name="Site Administrator" />
+    </permission>
+    <permission acquire="True"
                 name="collective.easyform: Edit Advanced Fields"
     >
       <role name="Manager" />
+      <role name="Owner" />
       <role name="Site Administrator" />
     </permission>
     <permission acquire="True"


### PR DESCRIPTION
Change semantics for the "advanced" permission and introduce new "technical" permission.
To better support use cases for "power users" while not overloading them with complex fields where a technical understanding is necessary the permissions are changed as follows:

"Edit Advanced Fields":
- IEasyForm.submitLabel
- IEasyForm.useCancelButton
- IEasyForm.resetLabel
- IEasyForm.form_tabbing
- IEasyForm.default_fieldset_label
- IFieldExtender.field_widget
- IFieldExtender.validators

"Edit Technical Fields":
- IEasyForm.method
- IEasyForm.unload_protection
- IEasyForm.CSRFProtection
- IEasyForm.forceSSL
- IMailer.replyto_field
- IMailer.xinfo_headers
- IMailer.additional_headers

Note: no upgrade step provided because this will be covered by the upgrade step in this PR:
https://github.com/collective/collective.easyform/pull/224