### PR TITLE
Lower button labels permission

### DIFF
--- a/news/229.breaking
+++ b/news/229.breaking
@@ -2,9 +2,6 @@ Change semantics for the "advanced" permission and introduce new "technical" per
 To better support use cases for "power users" while not overloading them with complex fields where a technical understanding is necessary the permissions are changed as follows:
 
 "Edit Advanced Fields":
-- IEasyForm.submitLabel
-- IEasyForm.useCancelButton
-- IEasyForm.resetLabel
 - IEasyForm.form_tabbing
 - IEasyForm.default_fieldset_label
 - IFieldExtender.field_widget

--- a/src/collective/easyform/interfaces/easyform.py
+++ b/src/collective/easyform/interfaces/easyform.py
@@ -196,21 +196,18 @@ class IEasyForm(Schema):
         ],
         order=20,
     )
-    directives.write_permission(submitLabel=config.EDIT_ADVANCED_PERMISSION)
     submitLabel = zope.schema.TextLine(
         title=_(u"label_submitlabel_text", default=u"Submit Button Label"),
         description=_(u"help_submitlabel_text", default=u""),
         defaultFactory=default_submitLabel,
         required=False,
     )
-    directives.write_permission(useCancelButton=config.EDIT_ADVANCED_PERMISSION)
     useCancelButton = zope.schema.Bool(
         title=_(u"label_showcancel_text", default=u"Show Reset Button"),
         description=_(u"help_showcancel_text", default=u""),
         default=False,
         required=False,
     )
-    directives.write_permission(resetLabel=config.EDIT_ADVANCED_PERMISSION)
     resetLabel = zope.schema.TextLine(
         title=_(u"label_reset_button", default=u"Reset Button Label"),
         description=_(u"help_reset_button", default=u""),


### PR DESCRIPTION
Allow non-privileged users to configure button labels. As these labels are not translated, you'd be stuck with whatever you get on form creation, even if changing the form's language afterwards.