### PR TITLE
fix actions urls when on action or field traverser

### DIFF
--- a/news/239.bugfix
+++ b/news/239.bugfix
@@ -1,0 +1,2 @@
+Fixes #182: actions urls when on action or field traverser. [jensens]
+

--- a/src/collective/easyform/profiles/default/actions.xml
+++ b/src/collective/easyform/profiles/default/actions.xml
@@ -34,7 +34,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <property name="url_expr">python:object_url + '/@@import-easyform' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else './@@import-easyform'</property>
+      <property name="url_expr">python:object_url + '/@@import-easyform' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../@@import-easyform'</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -52,7 +52,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <property name="url_expr">python:object_url + '/@@saveddata' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else './@@saveddata'</property>
+      <property name="url_expr">python:object_url + '/@@saveddata' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../@@saveddata'</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -73,7 +73,7 @@
       <!-- For some reason Zope is considering Fields & Actions views as canonical objects -->
       <!-- The condition below works around this by building 1) an absolute url for the form -->
       <!-- Or 2) a relative one when user is not at canonical view -->
-      <property name="url_expr">python:object_url + '/fields' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else './fields'</property>
+      <property name="url_expr">python:object_url + '/fields' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../fields'</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -92,7 +92,7 @@
                 i18n:translate=""
       />
       <!-- For some reason Zope is considering Fields & Actions views as canonical objects -->
-      <property name="url_expr">python:object_url + '/actions' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else './actions'</property>
+      <property name="url_expr">python:object_url + '/actions' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../actions'</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">


### PR DESCRIPTION
URLs in actions menu pointed to `form/actions/fields` if on `form/actions`. now fixed.