### PR TITLE
Robot tests: make click in contentmenu actions more specific.

### DIFF
--- a/src/collective/easyform/tests/robot/keywords.robot
+++ b/src/collective/easyform/tests/robot/keywords.robot
@@ -51,12 +51,12 @@ Wait overlay is closed
     Wait until keyword succeeds  60  1  Page should not contain element  css=div.overlay
 
 Clicked Fields
-    Click Link  css=#plone-contentmenu-actions a
+    Click Link  css=#plone-contentmenu-actions > a
     Element should be visible  css=#plone-contentmenu-actions ul
     Click Link  css=#plone-contentmenu-actions ul a#plone-contentmenu-actions-Fields
 
 Clicked Actions
-    Click Link  css=#plone-contentmenu-actions a
+    Click Link  css=#plone-contentmenu-actions > a
     Element should be visible  css=#plone-contentmenu-actions ul
     Click Link  css=#plone-contentmenu-actions ul a#plone-contentmenu-actions-Actions
 


### PR DESCRIPTION
When I try the original in a real browser, I get a click on *all* a-tags within the actions menu.
This means that several popup windows appear.
Clicking only the immediately contained a-tag means only the menu is opened.
I hope this fixes https://github.com/collective/collective.easyform/issues/244