### PR TITLE
Fix action urls and tests.

### DIFF
--- a/news/219.bugfix
+++ b/news/219.bugfix
@@ -1,0 +1,4 @@
+Make sure action urls are always relative to the easyform object.
+See `issue 219 <https://github.com/collective/collective.easyform/issues/219>`_
+and `PR 239 <https://github.com/collective/collective.easyform/pull/239>`_.
+[maurits]

--- a/news/219.bugfix
+++ b/news/219.bugfix
@@ -1,5 +1,6 @@
 Make sure action urls are always relative to the easyform object.
 And redirect `folder/easyform/folder_contents` to `folder/folder_contents`.
+And show a View link in the toolbar when you are in a sub item of a form.
 See `issue 219 <https://github.com/collective/collective.easyform/issues/219>`_
 and `PR 239 <https://github.com/collective/collective.easyform/pull/239>`_.
 [maurits]

--- a/news/219.bugfix
+++ b/news/219.bugfix
@@ -1,4 +1,5 @@
 Make sure action urls are always relative to the easyform object.
+And redirect `folder/easyform/folder_contents` to `folder/folder_contents`.
 See `issue 219 <https://github.com/collective/collective.easyform/issues/219>`_
 and `PR 239 <https://github.com/collective/collective.easyform/pull/239>`_.
 [maurits]

--- a/src/collective/easyform/browser/configure.zcml
+++ b/src/collective/easyform/browser/configure.zcml
@@ -38,6 +38,13 @@
       layer="..interfaces.IEasyFormLayer"
       />
   <browser:page
+      name="is-sub-easyform"
+      for="*"
+      permission="zope2.View"
+      class=".view.IsSubEasyForm"
+      layer="..interfaces.IEasyFormLayer"
+      />
+  <browser:page
       name="folder_contents"
       for="collective.easyform.interfaces.IEasyForm"
       permission="zope2.View"

--- a/src/collective/easyform/browser/configure.zcml
+++ b/src/collective/easyform/browser/configure.zcml
@@ -37,6 +37,12 @@
       class=".view.GetEasyFormURL"
       layer="..interfaces.IEasyFormLayer"
       />
+  <browser:page
+      name="folder_contents"
+      for="collective.easyform.interfaces.IEasyForm"
+      permission="zope2.View"
+      class=".view.FolderContentsView"
+      />
   <configure zcml:condition="installed plone.dexterity.exportimport">
     <browser:page
         name="export-easyform"

--- a/src/collective/easyform/browser/configure.zcml
+++ b/src/collective/easyform/browser/configure.zcml
@@ -30,6 +30,13 @@
       class=".controlpanel.EasyFormControlPanelView"
       layer="..interfaces.IEasyFormLayer"
       />
+  <browser:page
+      name="get-easyform-url"
+      for="*"
+      permission="zope2.View"
+      class=".view.GetEasyFormURL"
+      layer="..interfaces.IEasyFormLayer"
+      />
   <configure zcml:condition="installed plone.dexterity.exportimport">
     <browser:page
         name="export-easyform"

--- a/src/collective/easyform/browser/easyform.css
+++ b/src/collective/easyform/browser/easyform.css
@@ -59,3 +59,7 @@
     content: '\e028';
     top: 2px;
 }
+
+.icon-easyform-view.toolbar-menu-icon::before {
+    content: '\e807';
+}

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -470,5 +470,19 @@ class GetEasyFormURL(BrowserView):
                 return
 
 
+class FolderContentsView(BrowserView):
+    """folder_contents view for EasyForm.
+
+    When you are at url easyform/fields the Contents link in the toolbar
+    points to easyform/folder_contents, which does not exist.
+    So let's redirect to the parent.
+    """
+
+    def __call__(self):
+        url = aq_parent(self.context).absolute_url() + "/folder_contents"
+        self.request.response.redirect(url)
+        return url
+
+
 # BBB
 ValidateFileSize = ValidateFile

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -490,7 +490,6 @@ class IsSubEasyForm(GetEasyFormURL):
         return True
 
 
-
 class FolderContentsView(BrowserView):
     """folder_contents view for EasyForm.
 

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -470,6 +470,27 @@ class GetEasyFormURL(BrowserView):
                 return
 
 
+class IsSubEasyForm(GetEasyFormURL):
+    """Is this a sub object of an easyform?
+
+    For use in actions.xml.
+
+    If this is a sub object of easyform,
+    then if has portal_type EasyForm,
+    but only due to acquisition.
+    """
+
+    def __call__(self):
+        if self.context.portal_type != "EasyForm":
+            # The wrong portal_type.
+            return False
+        if hasattr(aq_base(self.context), "portal_type"):
+            # An actual EasyForm
+            return False
+        return True
+
+
+
 class FolderContentsView(BrowserView):
     """folder_contents view for EasyForm.
 

--- a/src/collective/easyform/profiles/default/actions.xml
+++ b/src/collective/easyform/profiles/default/actions.xml
@@ -4,6 +4,29 @@
         name="portal_actions"
 >
   <object meta_type="CMF Action Category"
+          name="object"
+  >
+    <object meta_type="CMF Action"
+            name="easyform-view"
+            insert-after="folderContents"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >View</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm' and object.restrictedTraverse('@@is-sub-easyform')()</property>
+      <property name="permissions">
+        <element value="Manage portal" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+  <object meta_type="CMF Action Category"
           name="object_buttons"
   >
     <object meta_type="CMF Action"

--- a/src/collective/easyform/profiles/default/actions.xml
+++ b/src/collective/easyform/profiles/default/actions.xml
@@ -16,7 +16,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <property name="url_expr">python:object_url + '/@@export-easyform' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else './@@export-easyform'</property>
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@export-easyform')</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -34,7 +34,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <property name="url_expr">python:object_url + '/@@import-easyform' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../@@import-easyform'</property>
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@import-easyform')</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -52,7 +52,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <property name="url_expr">python:object_url + '/@@saveddata' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../@@saveddata'</property>
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@saveddata')</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -70,10 +70,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <!-- For some reason Zope is considering Fields & Actions views as canonical objects -->
-      <!-- The condition below works around this by building 1) an absolute url for the form -->
-      <!-- Or 2) a relative one when user is not at canonical view -->
-      <property name="url_expr">python:object_url + '/fields' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../fields'</property>
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('fields')</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
@@ -91,8 +88,7 @@
       <property name="description"
                 i18n:translate=""
       />
-      <!-- For some reason Zope is considering Fields & Actions views as canonical objects -->
-      <property name="url_expr">python:object_url + '/actions' if context.restrictedTraverse('@@plone_interface_info').provides('collective.easyform.interfaces.IEasyForm') else '../actions'</property>
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('actions')</property>
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">

--- a/src/collective/easyform/profiles/default/metadata.xml
+++ b/src/collective/easyform/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1006</version>
+  <version>1007</version>
 </metadata>

--- a/src/collective/easyform/tests/robot/keywords.robot
+++ b/src/collective/easyform/tests/robot/keywords.robot
@@ -51,12 +51,12 @@ Wait overlay is closed
     Wait until keyword succeeds  60  1  Page should not contain element  css=div.overlay
 
 Clicked Fields
-    Click Link  css=#plone-contentmenu-actions a
+    Click Link  css=#plone-contentmenu-actions > a
     Element should be visible  css=#plone-contentmenu-actions ul
     Click Link  css=#plone-contentmenu-actions ul a#plone-contentmenu-actions-Fields
 
 Clicked Actions
-    Click Link  css=#plone-contentmenu-actions a
+    Click Link  css=#plone-contentmenu-actions > a
     Element should be visible  css=#plone-contentmenu-actions ul
     Click Link  css=#plone-contentmenu-actions ul a#plone-contentmenu-actions-Actions
 

--- a/src/collective/easyform/tests/testMisc.py
+++ b/src/collective/easyform/tests/testMisc.py
@@ -9,6 +9,7 @@ from collective.easyform.browser.fields import AjaxSaveHandler
 from collective.easyform.tests import base
 from plone import api
 from plone.namedfile.file import NamedFile
+from zope.component import getMultiAdapter
 
 
 class TestMisc(base.EasyFormTestCase):
@@ -27,6 +28,53 @@ class TestMisc(base.EasyFormTestCase):
         # Check if the submitLabel is translated at all.
         # If you ever change the german translation of the submit label, change it here also
         self.assertEqual(self.folder.ff1.submitLabel, "Absenden")
+
+
+class TestGetEasyFormURL(base.EasyFormTestCase):
+    """ test GetEasyFormURL stuff """
+
+    def afterSetUp(self):
+        self.folder.invokeFactory("EasyForm", "ff1")
+        self.form = self.folder.ff1
+        self.form_url = self.form.absolute_url()
+
+    def get_view(self, context):
+        request = self.layer["request"]
+        return getMultiAdapter((context, request), name="get-easyform-url")
+
+    def check_urls_form(self, view):
+        # For a view somewhere in a form
+        self.assertEqual(view("fields"), self.form_url + "/fields")
+        self.assertEqual(view("/fields"), self.form_url + "/fields")
+        self.assertEqual(view("actions"), self.form_url + "/actions")
+        self.assertEqual(view(""), self.form_url + "")
+
+    def check_urls_non_form(self, view):
+        # For a view outside a form
+        self.assertEqual(view("fields"), "./fields")
+        self.assertEqual(view("/fields"), "./fields")
+        self.assertEqual(view("actions"), "./actions")
+        self.assertEqual(view(""), "./")
+
+    def test_get_easyform_url_form(self):
+        view = self.get_view(self.form)
+        self.check_urls_form(view)
+
+    def test_get_easyform_url_fields(self):
+        view = self.get_view(self.form.restrictedTraverse("fields"))
+        self.check_urls_form(view)
+
+    def test_get_easyform_url_actions(self):
+        view = self.get_view(self.form.restrictedTraverse("actions"))
+        self.check_urls_form(view)
+
+    def test_get_easyform_url_folder(self):
+        view = self.get_view(self.folder)
+        self.check_urls_non_form(view)
+
+    def test_get_easyform_url_portal(self):
+        view = self.get_view(self.portal)
+        self.check_urls_non_form(view)
 
 
 class TestAjaxSaveHandler(base.EasyFormTestCase):

--- a/src/collective/easyform/tests/testMisc.py
+++ b/src/collective/easyform/tests/testMisc.py
@@ -77,6 +77,39 @@ class TestGetEasyFormURL(base.EasyFormTestCase):
         self.check_urls_non_form(view)
 
 
+class TestIsSubEasyForm(base.EasyFormTestCase):
+    """ test IsSubEasyForm stuff """
+
+    def afterSetUp(self):
+        self.folder.invokeFactory("EasyForm", "ff1")
+        self.form = self.folder.ff1
+        self.form_url = self.form.absolute_url()
+
+    def get_view(self, context):
+        request = self.layer["request"]
+        return getMultiAdapter((context, request), name="is-sub-easyform")
+
+    def test_is_sub_easyform_form(self):
+        view = self.get_view(self.form)
+        self.assertFalse(view())
+
+    def test_is_sub_easyform_fields(self):
+        view = self.get_view(self.form.restrictedTraverse("fields"))
+        self.assertTrue(view())
+
+    def test_is_sub_easyform_actions(self):
+        view = self.get_view(self.form.restrictedTraverse("actions"))
+        self.assertTrue(view())
+
+    def test_is_sub_easyform_folder(self):
+        view = self.get_view(self.folder)
+        self.assertFalse(view())
+
+    def test_is_sub_easyform_root(self):
+        view = self.get_view(self.portal)
+        self.assertFalse(view())
+
+
 class TestAjaxSaveHandler(base.EasyFormTestCase):
     def test_ajax_save_handler_call_unathorized(self):
         self.folder.invokeFactory("EasyForm", "ff1")

--- a/src/collective/easyform/upgrades/1007.zcml
+++ b/src/collective/easyform/upgrades/1007.zcml
@@ -1,0 +1,18 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    >
+
+  <gs:upgradeSteps
+      destination="1007"
+      profile="collective.easyform:default"
+      source="1006"
+      >
+    <gs:upgradeDepends
+        title="Import actions"
+        import_steps="actions"
+        run_deps="false"
+        />
+  </gs:upgradeSteps>
+
+</configure>

--- a/src/collective/easyform/upgrades/configure.zcml
+++ b/src/collective/easyform/upgrades/configure.zcml
@@ -5,4 +5,5 @@
   <include file="1004.zcml" />
   <include file="1005.zcml" />
   <include file="1006.zcml" />
+  <include file="1007.zcml" />
 </configure>


### PR DESCRIPTION
See issue #219, issue #244, PR #239.
Includes upgrade step to apply the `actions.xml`.

Note that this adds a View link in the toolbar when you are within the Fields or Actions views, but it is at a different position than normally, because the normal position is only available for real content items.
The order is: Contents, Actions, View (followed by History and Sharing)