### PR TITLE
Add upgrade profile and step to update the bundle timestamp.

### DIFF
--- a/src/collective/easyform/profiles/1007/actions.xml
+++ b/src/collective/easyform/profiles/1007/actions.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Plone Actions Tool"
+        name="portal_actions"
+>
+  <object meta_type="CMF Action Category"
+          name="object"
+  >
+    <object meta_type="CMF Action"
+            name="easyform-view"
+            insert-after="folderContents"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >View</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm' and object.restrictedTraverse('@@is-sub-easyform')()</property>
+      <property name="permissions">
+        <element value="Manage portal" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+  <object meta_type="CMF Action Category"
+          name="object_buttons"
+  >
+    <object meta_type="CMF Action"
+            name="export"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >Export</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@export-easyform')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
+      <property name="permissions">
+        <element value="Manage portal" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="import"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >Import</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@import-easyform')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
+      <property name="permissions">
+        <element value="Manage portal" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="saveddata"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >Saved data</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@saveddata')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="Fields"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >Define form fields</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('fields')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="Actions"
+            i18n:domain="collective.easyform"
+    >
+      <property name="title"
+                i18n:translate=""
+      >Define form actions</property>
+      <property name="description"
+                i18n:translate=""
+      />
+      <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('actions')</property>
+      <property name="icon_expr" />
+      <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
+      <property name="permissions">
+        <element value="Modify portal content" />
+      </property>
+      <property name="visible">True</property>
+    </object>
+  </object>
+</object>

--- a/src/collective/easyform/profiles/1007/registry.xml
+++ b/src/collective/easyform/profiles/1007/registry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<registry>
+
+  <records interface="Products.CMFPlone.interfaces.IBundleRegistry"
+           prefix="plone.bundles/easyform"
+  >
+    <value key="last_compilation">2020-09-08 17:52:00</value>
+  </records>
+
+</registry>

--- a/src/collective/easyform/profiles/default/registry.xml
+++ b/src/collective/easyform/profiles/default/registry.xml
@@ -66,7 +66,7 @@
     <value key="compile">False</value>
     <value key="csscompilation">++resource++easyform.css</value>
     <value key="depends">plone</value>
-    <value key="last_compilation">2019-04-24 15:10:00</value>
+    <value key="last_compilation">2020-09-08 17:52:00</value>
     <value key="resources">
     </value>
     <value key="merge_with">default</value>

--- a/src/collective/easyform/setuphandlers.py
+++ b/src/collective/easyform/setuphandlers.py
@@ -6,5 +6,5 @@ from zope.interface import implementer
 @implementer(INonInstallable)
 class HiddenProfiles(object):
     def getNonInstallableProfiles(self):
-        """Hide uninstall profile from site-creation and quickinstaller."""
-        return ["collective.easyform:uninstall"]
+        """Hide profiles from site-creation and quickinstaller."""
+        return ["collective.easyform:uninstall", "collective.easyform.upgrades:1007"]

--- a/src/collective/easyform/upgrades/1007.zcml
+++ b/src/collective/easyform/upgrades/1007.zcml
@@ -3,15 +3,21 @@
     xmlns:gs="http://namespaces.zope.org/genericsetup"
     >
 
+  <gs:registerProfile
+      name="1007"
+      title="Upgrade to 1007"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="../profiles/1007"
+      />
+
   <gs:upgradeSteps
       destination="1007"
       profile="collective.easyform:default"
       source="1006"
       >
     <gs:upgradeDepends
-        title="Import actions"
-        import_steps="actions"
-        run_deps="false"
+        title="Update actions, update bundle timestamp, combine bundles"
+        import_profile="collective.easyform.upgrades:1007"
         />
   </gs:upgradeSteps>
 


### PR DESCRIPTION
This is a follow-up on https://github.com/collective/collective.easyform/pull/247#discussion_r485139502
That PR updated the actions, with an upgrade step, but also changed css, which was missing an upgrade step. That is what I do here. This is an upgrade profile, so we have one upgrade step that applies the actions, updates the bundle timestamp, and combines the bundles.

I first tried it smaller, with only a tiny upgrade step, but that was not enough.
See branch `maurits/upgrade-step-bundle-1`, commit e15cd7d76d9fce7d78af99fe372c6cd27b03808d and the commented-out ideas in that commit.

cc @thet because I wonder if he knows something simpler than either this PR or the ideas in the commit I reference.

I could imagine a new function in `CMFPlone` that takes a bundle prefix and a timestamp, and sets the last compilation date on this bundle, and calls combine-bundles, taking care that the ContentType of the response is not changed to json. So roughly the `update_last_compilation` function I have in commit e15cd7d76d9fce7d78af99fe372c6cd27b03808d, plus the combine-bundles from the comments there.