### PR TITLE
Set last_compilation date and combine bundles

### DIFF
--- a/src/collective/easyform/profiles/default/registry.xml
+++ b/src/collective/easyform/profiles/default/registry.xml
@@ -66,7 +66,8 @@
     <value key="compile">False</value>
     <value key="csscompilation">++resource++easyform.css</value>
     <value key="depends">plone</value>
-    <value key="last_compilation">2019-04-24 15:10:00</value>
+    <!-- Please keep this in sync with upgrades.update_last_compilation -->
+    <value key="last_compilation">2020-09-08 17:52:00</value>
     <value key="resources">
     </value>
     <value key="merge_with">default</value>

--- a/src/collective/easyform/tests/testSetup.py
+++ b/src/collective/easyform/tests/testSetup.py
@@ -147,3 +147,13 @@ class TestInstallation(base.EasyFormTestCase):
         self.assertEqual(
             self.types.EasyForm.getAvailableViewMethods(self.types), ("view",)
         )
+
+    def test_upgrades(self):
+        portal_setup = self.portal.portal_setup
+        profile_id = "profile-collective.easyform:default"
+        self.assertFalse(portal_setup.hasPendingUpgrades())
+        portal_setup.setLastVersionForProfile(profile_id, "1000")
+        self.assertTrue(portal_setup.hasPendingUpgrades())
+        # Biggest test is: do the upgrades run without error?
+        portal_setup.upgradeProfile(profile_id)
+        self.assertFalse(portal_setup.hasPendingUpgrades())

--- a/src/collective/easyform/upgrades/1007.zcml
+++ b/src/collective/easyform/upgrades/1007.zcml
@@ -13,6 +13,10 @@
         import_steps="actions"
         run_deps="false"
         />
+    <gs:upgradeStep
+        title="Update last_compilation of bundle"
+        handler=".update_last_compilation"
+        />
   </gs:upgradeSteps>
 
 </configure>

--- a/src/collective/easyform/upgrades/__init__.py
+++ b/src/collective/easyform/upgrades/__init__.py
@@ -1,3 +1,11 @@
+from plone import api
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
 def update_last_compilation(context):
     # Let's do the imports inline, so they are not needlessly done at startup.
     # Should not really matter, but oh well.
@@ -11,19 +19,24 @@ def update_last_compilation(context):
     # Technically we only need year, month and day.
     # But keep this in sync with registry.xml.
     records.last_compilation = datetime(2020, 9, 8, 17, 52, 0)
-    # TODO: run the combine-bundles import step or its handler
-    # Products.CMFPlone.resources.exportimport.bundles.combine.
-    # But that only does something when there is a registry.xml,
-    # so I don't think it works for an upgrade step.
-    #
-    # But this is a wrapper around
-    # Products.CMFPlone.resources.browser.combine.combine_bundles
-    # which we could call directly, but then we need to do the same
-    # extra handling of the response contenttype.
-    #
-    # We could also re-apply our whole registry.xml,
-    # by doing an upgradeDepends with plone.app.registry and combine-bundles,
-    # but that restores our factory defaults, which we should not do.
-    #
-    # Easiest is to add an upgrade profile.
-    # I always consider that overkill, but so be it.
+    logger.info("Updated the last_compilation date of the easyform bundle.")
+
+    # Run the combine-bundles import step or its handler.
+    # Can be done with an upgrade step:
+    #   <gs:upgradeDepends
+    #     title="combine bundles"
+    #     import_steps="combine-bundles"
+    #     run_deps="false"
+    #     />
+    # But directly calling the basic function works fine.
+    # See also comment here:
+    # https://github.com/collective/collective.easyform/pull/248#issuecomment-689365240
+    # Also, here we can do a try/except so it does not fail on Plone 5.0,
+    # which I think does not have the import step, not the function.
+    try:
+        from Products.CMFPlone.resources.browser.combine import combine_bundles
+    except ImportError:
+        logger.warning("Could not call combine_bundles. You should do that yourself.")
+        return
+    portal = api.portal.get()
+    combine_bundles(portal)

--- a/src/collective/easyform/upgrades/__init__.py
+++ b/src/collective/easyform/upgrades/__init__.py
@@ -1,0 +1,29 @@
+def update_last_compilation(context):
+    # Let's do the imports inline, so they are not needlessly done at startup.
+    # Should not really matter, but oh well.
+    from datetime import datetime
+    from plone.registry.interfaces import IRegistry
+    from zope.component import getUtility
+    from Products.CMFPlone.interfaces import IBundleRegistry
+
+    registry = getUtility(IRegistry)
+    records = registry.forInterface(IBundleRegistry, prefix="plone.bundles/easyform")
+    # Technically we only need year, month and day.
+    # But keep this in sync with registry.xml.
+    records.last_compilation = datetime(2020, 9, 8, 17, 52, 0)
+    # TODO: run the combine-bundles import step or its handler
+    # Products.CMFPlone.resources.exportimport.bundles.combine.
+    # But that only does something when there is a registry.xml,
+    # so I don't think it works for an upgrade step.
+    #
+    # But this is a wrapper around
+    # Products.CMFPlone.resources.browser.combine.combine_bundles
+    # which we could call directly, but then we need to do the same
+    # extra handling of the response contenttype.
+    #
+    # We could also re-apply our whole registry.xml,
+    # by doing an upgradeDepends with plone.app.registry and combine-bundles,
+    # but that restores our factory defaults, which we should not do.
+    #
+    # Easiest is to add an upgrade profile.
+    # I always consider that overkill, but so be it.


### PR DESCRIPTION
This replaces PR #248 in a much simpler way, now that I know more what I am doing.

This tries to not break on Plone 5.0, which does not have the `combine_bundles` function. We could also drop 5.0 support. But the tests *should* still pass.