### PR TITLE
Add missing "context" parameter to translate method for labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Bug fixes:
 - For increased security, in the modeleditor do not resolve entities, and remove processing instructions.
   [maurits] (#3209)
 
+- Add missing "context" parameter to translate method for labels (context aware default value).
+  [mathias.leimgruber]
+
 
 2.2.0 (2020-06-04)
 ------------------

--- a/src/collective/easyform/interfaces/easyform.py
+++ b/src/collective/easyform/interfaces/easyform.py
@@ -22,22 +22,26 @@ PMF = zope.i18nmessageid.MessageFactory("plone")
 
 @provider(zope.schema.interfaces.IContextAwareDefaultFactory)
 def default_submitLabel(context):
-    return translate(_(u"default_submitLabel", u"Submit"))
+    return translate(_(u"default_submitLabel", u"Submit"),
+                     context=api.portal.get().REQUEST)
 
 
 @provider(zope.schema.interfaces.IContextAwareDefaultFactory)
 def default_resetLabel(context):
-    return translate(_(u"default_resetLabel", u"Reset"))
+    return translate(_(u"default_resetLabel", u"Reset"),
+                     context=api.portal.get().REQUEST)
 
 
 @provider(zope.schema.interfaces.IContextAwareDefaultFactory)
 def default_thankstitle(context):
-    return translate(_(u"default_thankstitle", u"Thank You"))
+    return translate(_(u"default_thankstitle", u"Thank You"),
+                     context=api.portal.get().REQUEST)
 
 
 @provider(zope.schema.interfaces.IContextAwareDefaultFactory)
 def default_thanksdescription(context):
-    return translate(_(u"default_thanksdescription", u"Thanks for your input."))
+    return translate(_(u"default_thanksdescription", u"Thanks for your input."),
+                     context=api.portal.get().REQUEST)
 
 
 @zope.interface.provider(zope.schema.interfaces.IContextAwareDefaultFactory)


### PR DESCRIPTION
The translate method from zope.i18n needs the request as context
to determine the language.

After this change the labels actually get translated:
<img width="517" alt="Screenshot 2021-02-04 at 09 42 12" src="https://user-images.githubusercontent.com/437933/106910981-bd973980-66cf-11eb-9688-145903beb669.png">
<img width="414" alt="Screenshot 2021-02-04 at 09 42 05" src="https://user-images.githubusercontent.com/437933/106910987-be2fd000-66cf-11eb-8950-1f2f422f3f85.png">

Before the english default value was returned.
