### PR TITLE
Backport PloneFormGen migration to 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ install:
   - bin/buildout -t 5 -Nq
 before_script:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  # - "sh -e /etc/init.d/xvfb start"
 script:
   - bin/test

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.0a5.0 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Backport PloneFormGen migration from 2.x.
+  [thomasmassmann]
 
 
 1.0a4 (2020-11-17)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -11,3 +11,4 @@ eggs =
 plone.schemaeditor = 2.0.7
 setuptools = 40.8.0
 zc.buildout = 2.13.1
+Pillow = 5.4.1

--- a/collective/easyform/configure.zcml
+++ b/collective/easyform/configure.zcml
@@ -3,6 +3,7 @@
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="collective.easyform">
 
   <include package="plone.app.dexterity" />
@@ -18,6 +19,7 @@
   <include file="vocabularies.zcml" />
 
   <include package=".browser" />
+  <include zcml:condition="installed Products.PloneFormGen" package=".migration" />
 
   <genericsetup:registerProfile
       name="default"

--- a/collective/easyform/migration/actions.py
+++ b/collective/easyform/migration/actions.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+from collective.easyform.migration.fields import append_field
+from collective.easyform.migration.fields import append_list_node
+from collective.easyform.migration.fields import append_node
+from collective.easyform.migration.fields import set_attribute
+from collective.easyform.migration.fields import to_text
+from lxml import etree
+from Products.PloneFormGen.content.actionAdapter import FormActionAdapter
+
+import logging
+
+try:
+  from collective.easyform.interfaces.mailer import default_mail_body
+except ImportError:
+  from collective.easyform.config import MAIL_BODY_DEFAULT
+  def default_mail_body():
+    return MAIL_BODY_DEFAULT
+
+
+logger = logging.getLogger('collective.easyform.migration')
+
+
+NAMESPACES = {
+    'easyform': 'http://namespaces.plone.org/supermodel/easyform',
+    'form': 'http://namespaces.plone.org/supermodel/form',
+}
+
+
+def append_body_pt(field, name, value):
+    node = append_node(field, name, value)
+    # Replace mailer page template with the default one from easyform as it's
+    # unlikely that the PFG template would work.
+    node.text = default_mail_body()
+
+
+Type = namedtuple('Type', ['name', 'handler'])
+Property = namedtuple('Property', ['name', 'handler'])
+
+
+TYPES_MAPPING = {
+    'FormMailerAdapter': Type('collective.easyform.actions.Mailer', append_field),
+    'FormSaveDataAdapter': Type('collective.easyform.actions.SaveData', append_field),
+    'FormCustomScriptAdapter': Type('collective.easyform.actions.CustomScript', append_field),
+}
+
+PROPERTIES_MAPPING = {
+    'additional_headers': Property('additional_headers', append_node),
+    'bcc_recipients': Property('bcc_recipients', append_node),
+    'bccOverride': Property('bccOverride', append_node),
+    'body_footer': Property('body_footer', append_node),
+    'body_post': Property('body_post', append_node),
+    'body_pre': Property('body_pre', append_node),
+    'body_pt': Property('body_pt', append_body_pt),
+    'body_type': Property('body_type', append_node),
+    'cc_recipients': Property('cc_recipients', append_node),
+    'ccOverride': Property('ccOverride', append_node),
+    'description': Property('description', append_node),
+    'execCondition': Property('easyform:execCondition', set_attribute),
+    'msg_subject': Property('msg_subject', append_node),
+    'recipient_email': Property('recipient_email', append_node),
+    'recipient_name': Property('recipient_name', append_node),
+    'recipientOverride': Property('recipientOverride', append_node),
+    'replyto_field': Property('replyto_field', append_node),
+    'senderOverride': Property('senderOverride', append_node),
+    'showAll': Property('showAll', append_node),
+    'showFields': Property('showFields', append_list_node),
+    'subject_field': Property('subject_field', append_node),
+    'subjectOverride': Property('subjectOverride', append_node),
+    'title': Property('title', append_node),
+    'to_field': Property('to_field', append_node),
+    'xinfo_headers': Property('xinfo_headers', append_node),
+    'ExtraData': Property('ExtraData', append_list_node),
+    'DownloadFormat': Property('DownloadFormat', append_node),
+    'UseColumnNames': Property('UseColumnNames', append_node),
+    'SavedFormInput': Property('SavedFormInput', append_node),
+    'ProxyRole': Property('ProxyRole', append_node),
+    'ScriptBody': Property('ScriptBody', append_node),
+}
+
+
+def pfg_actions(context):
+    actions = []
+    for obj in context.objectValues():
+        if not isinstance(obj, FormActionAdapter):
+            continue
+        id_ = obj.getId()
+        props = {}
+        props['_portal_type'] = obj.portal_type
+        for field in obj.Schema().fields():
+            name = field.getName()
+            accessor = field.getEditAccessor(obj)
+            props[name] = accessor()
+        actions.append((id_, props))
+    return actions
+
+
+def actions_model(ploneformgen):
+    """Create an actions xml model from a PloneFormGen instance."""
+    parser = etree.XMLParser(remove_blank_text=True)
+    model = etree.fromstring(ACTIONS_MODEL, parser)
+    schema = model.find(
+        '{http://namespaces.plone.org/supermodel/schema}schema')
+
+    for actionname, properties in pfg_actions(ploneformgen):
+        type_ = TYPES_MAPPING.get(properties['_portal_type'])
+        if type_ is None:
+            logger.warning(
+                "Ingoring field '%s' of type '%s'.",
+                actionname, properties['_portal_type'])
+            continue
+
+        field = type_.handler(schema, type_.name, actionname, properties)
+
+        for name, value in properties.items():
+            prop = PROPERTIES_MAPPING.get(name)
+            if prop is None:
+                continue
+
+            value = to_text(value)
+
+            prop.handler(field, prop.name, value)
+
+    return etree.tostring(model, pretty_print=True)
+
+
+ACTIONS_MODEL = b"""
+<model xmlns="http://namespaces.plone.org/supermodel/schema">
+  <schema></schema>
+</model>
+"""

--- a/collective/easyform/migration/configure.zcml
+++ b/collective/easyform/migration/configure.zcml
@@ -1,0 +1,13 @@
+<configure xmlns="http://namespaces.zope.org/zope"
+           xmlns:browser="http://namespaces.zope.org/browser"
+           xmlns:zcml="http://namespaces.zope.org/zcml"
+           i18n_domain="collective.easyform">
+
+    <browser:page
+        for="*"
+        name="migrate-ploneformgen"
+        class=".pfg.MigratePloneFormGenForm"
+        permission="cmf.ManagePortal"
+        />
+
+</configure>

--- a/collective/easyform/migration/data.py
+++ b/collective/easyform/migration/data.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from ast import literal_eval
+from collective.easyform.api import get_actions
+from collective.easyform.api import get_fields
+from collective.easyform.interfaces import ISaveData
+from DateTime import DateTime
+from plone.namedfile.interfaces import INamedBlobFileField
+from zope.schema.interfaces import IDate
+from zope.schema.interfaces import IDatetime
+from zope.schema.interfaces import IFromUnicode
+from zope.schema.interfaces import ISet
+
+import logging
+
+
+logger = logging.getLogger('collective.easyform.migration')
+
+
+def migrate_saved_data(ploneformgen, easyform):
+    for data_adapter in ploneformgen.objectValues('FormSaveDataAdapter'):
+        actions = get_actions(easyform)
+        action = actions.get(data_adapter.getId())
+        schema = get_fields(easyform)
+        if ISaveData.providedBy(action):
+            cols = data_adapter.getColumnNames()
+            for idx, row in enumerate(data_adapter.getSavedFormInput()):
+                if len(row) != len(cols):
+                    logger.warning(
+                        'Number of columns does not match. Skipping row %s in '
+                        'data adapter %s/%s', idx,
+                        '/'.join(easyform.getPhysicalPath()),
+                        data_adapter.getId())
+                    continue
+                data = {}
+                for key, value in zip(cols, row):
+                    field = schema.get(key)
+                    value = value.decode('utf8')
+                    if IFromUnicode.providedBy(field):
+                        value = field.fromUnicode(value)
+                    elif IDatetime.providedBy(field) and value:
+                        value = DateTime(value).asdatetime()
+                    elif IDate.providedBy(field) and value:
+                        value = DateTime(value).asdatetime().date()
+                    elif ISet.providedBy(field):
+                        try:
+                            value = set(literal_eval(value))
+                        except ValueError:
+                            pass
+                    elif INamedBlobFileField.providedBy(field):
+                        value = None
+                    data[key] = value
+                action.addDataRow(data)

--- a/collective/easyform/migration/fields.py
+++ b/collective/easyform/migration/fields.py
@@ -1,0 +1,285 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+from lxml import etree
+from Products.PloneFormGen.content.fields import FGFieldsetEnd
+from Products.PloneFormGen.content.fields import FGFieldsetStart
+from Products.PloneFormGen.content.fieldsBase import BaseFormField
+from Products.PloneFormGen.interfaces import IPloneFormGenFieldset
+
+import logging
+import six
+
+
+logger = logging.getLogger('collective.easyform.migration')
+
+
+NAMESPACES = {
+    'easyform': 'http://namespaces.plone.org/supermodel/easyform',
+    'form': 'http://namespaces.plone.org/supermodel/form',
+}
+
+
+def append_field(schema, type_, name, properties):
+    field = etree.SubElement(schema, u'field')
+    field.set(u'name', name)
+    field.set(u'type', type_)
+    return field
+
+
+def append_label_field(schema, type_, name, properties):
+    field = append_field(schema, type_, name, properties)
+    append_node(field, u'required', u'False')
+    return field
+
+
+def append_date_field(schema, type_, name, properties):
+    if properties.get('fgShowHM', False):
+        return append_field(schema, u'zope.schema.Datetime', name, properties)
+    else:
+        return append_field(schema, u'zope.schema.Date', name, properties)
+
+
+def append_fieldset(schema, type_, name, properties):
+    fieldset = etree.SubElement(schema, u'fieldset')
+    fieldset.set(u'name', name)
+    return fieldset
+
+
+def set_attribute(field, name, value):
+    if u':' in name:
+        ns, attr = name.split(':')
+        ns = NAMESPACES.get(ns, ns)
+        field.set(u'{{{}}}{}'.format(ns, attr), value)
+    else:
+        field.set(name, value)
+
+
+def append_node(field, name, value):
+    if ':' in name:
+        ns, name = name.split(':')
+        ns = NAMESPACES.get(ns, ns)
+        name = '{{{}}}{}'.format(ns, name)
+    node = etree.SubElement(field, name)
+    if isinstance(value, (list, tuple)):
+        value = u' '.join(value)
+    node.text = value
+    return node
+
+
+def append_list_node(field, name, value):
+    node = append_node(field, name, None)
+    for val in value:
+        el = etree.SubElement(node, 'element')
+        if '|' in val:
+            key, val = val.split('|')
+            el.set('key', key)
+        el.text = val
+
+
+def append_required_node(field, name, value):
+    if value == u'False':
+        append_node(field, name, value)
+
+
+def append_maxlength_node(field, name, value):
+    if value != u'0':
+        append_node(field, name, value)
+
+
+def append_vocab_node(field, name, value):
+    if field.get('type') == 'zope.schema.Set':
+        node = etree.SubElement(field, 'value_type')
+        node.set('type', 'zope.schema.Choice')
+    else:
+        node = field
+
+    append_list_node(node, u'values', value)
+
+
+def append_default_node(field, name, value):
+    if isinstance(value, list):
+        return
+    if field.get('type') == 'collective.easyform.fields.RichLabel':
+        append_node(field, 'rich_label', value)
+    else:
+        append_node(field, name, value)
+
+
+def append_widget_node(field, name, value):
+    node = append_node(field, name, None)
+    type_ = field.get('type')
+    if type_ == 'zope.schema.Set':
+        if value == 'select':
+            widget = 'z3c.form.browser.select.CollectionSelectFieldWidget'
+        else:
+            widget = 'z3c.form.browser.checkbox.CheckBoxFieldWidget'
+    else:
+        if value == 'select':
+            widget = 'z3c.form.browser.select.ChoiceWidgetDispatcher'
+        else:
+            widget = 'z3c.form.browser.radio.RadioFieldWidget'
+    set_attribute(node, 'type', widget)
+
+
+def append_or_set_title(field, name, value):
+    if field.tag == 'fieldset':
+        set_attribute(field, 'label', value)
+    else:
+        append_node(field, name, value)
+
+def append_or_set_description(field, name, value):
+    if field.tag == 'fieldset':
+        set_attribute(field, 'description', value)
+    else:
+        append_node(field, name, value)
+
+
+def convert_tales_expressions(value):
+    if value == u'here/memberEmail':
+        return u"python:member and member.getProperty('email', '') or ''"
+    elif value == u'here/memberFullName':
+        return u"python:member and member.getProperty('fullname', '') or ''"
+    elif value == u'here/memberId':
+        return u"python:member and member.id or ''"
+    return value
+
+
+def to_text(value):
+    if isinstance(value, (list, tuple)):
+        return [to_text(v) for v in value]
+    value = str(value)
+    if six.PY2:
+        value = value.decode('utf8')
+    return value
+
+
+Type = namedtuple('Type', ['name', 'handler'])
+Property = namedtuple('Property', ['name', 'handler'])
+
+TYPES_MAPPING = {
+    'FormStringField': Type('zope.schema.TextLine', append_field),
+    'FormPasswordField': Type('zope.schema.Password', append_field),
+    'FormIntegerField': Type('zope.schema.Int', append_field),
+    'FormFixedPointField': Type('zope.schema.Float', append_field),
+    'FormBooleanField': Type('zope.schema.Bool', append_field),
+    'FormDateField': Type('zope.schema.Date', append_date_field),
+    'FormLabelField': Type('collective.easyform.fields.Label', append_label_field),
+    'FormLinesField': Type('zope.schema.Text', append_field),
+    'FormSelectionField': Type('zope.schema.Choice', append_field),
+    'FormMultiSelectionField': Type('zope.schema.Set', append_field),
+    'FormTextField': Type('zope.schema.Text', append_field),
+    'FormRichTextField': Type('plone.app.textfield.RichText', append_field),
+    'FormRichLabelField': Type('collective.easyform.fields.RichLabel', append_label_field),
+    'FormFileField': Type('plone.namedfile.field.NamedBlobFile', append_field),
+    'FormCaptchaField': Type('collective.easyform.fields.ReCaptcha', append_field),
+    'FieldsetStart': Type('', append_fieldset),
+    'FieldsetEnd': Type('', None),
+}
+
+PROPERTIES_MAPPING = {
+    'description': Property('description', append_or_set_description),
+    'fgDefault': Property('default', append_default_node),
+    'fgmaxlength': Property('max_length', append_maxlength_node),
+    'fgsize': None,  # Not available in collective.easyform
+    'fgStringValidator': Property('easyform:validators', set_attribute),
+    'fgTDefault': Property('easyform:TDefault', set_attribute),
+    'fgTEnabled': Property('easyform:TEnabled', set_attribute),
+    'fgTValidator': Property('easyform:TValidator', set_attribute),
+    'fgTVocabulary': None,  # Not available in collective.easyform
+    'fgVocabulary': Property('values', append_vocab_node),
+    'hidden': Property('easyform:THidden', set_attribute),
+    'maxval': Property('max', append_node),
+    'minval': Property('min', append_node),
+    'placeholder': None,  # Not available in collective.easyform
+    'required': Property('required', append_required_node),
+    'serverSide': Property('easyform:serverSide', set_attribute),
+    'title': Property('title', append_or_set_title),
+    'fgFormat': Property('form:widget', append_widget_node),
+}
+
+
+def pfg_fields_properties(obj):
+    id_ = obj.getId()
+    props = {}
+    props['_portal_type'] = obj.portal_type
+    for field in obj.Schema().fields():
+        name = field.getName()
+        accessor = field.getEditAccessor(obj)
+        props[name] = accessor()
+    return (id_, props)
+
+
+def pfg_fields(context):
+    fields = []
+    for obj in context.objectValues():
+        if IPloneFormGenFieldset.providedBy(obj):
+            # handle FieldsetFolder folderish type
+            parent = obj.aq_parent
+            obj_id = obj.getId()
+            # append a FieldsetStart field with title and description
+            start = FGFieldsetStart(obj_id).__of__(parent)
+            start.setTitle(obj.Title())
+            start.setDescription(obj.Description())
+            fields.append(pfg_fields_properties(start))
+            # add all the fieldset contained fields
+            fields.extend(pfg_fields(obj))
+            # finish by appending a marker FieldsetEnd field
+            end = FGFieldsetEnd(obj_id).__of__(parent)
+            fields.append(pfg_fields_properties(end))
+            continue
+        if not isinstance(obj, BaseFormField):
+            continue
+        fields.append(pfg_fields_properties(obj))
+    return fields
+
+
+def fields_model(ploneformgen):
+    """Create a fields xml model from a PloneFormGen instance."""
+    parser = etree.XMLParser(remove_blank_text=True)
+    model = etree.fromstring(FIELDS_MODEL, parser)
+    schema = model.find(
+        '{http://namespaces.plone.org/supermodel/schema}schema')
+    for fieldname, properties in pfg_fields(ploneformgen):
+        portal_type = properties['_portal_type']
+        if portal_type == 'FieldsetEnd':
+            schema = schema.getparent()
+            continue
+
+        type_ = TYPES_MAPPING.get(portal_type)
+        if type_ is None:
+            logger.warning(
+                "Ingoring field '%s' of type '%s'.", fieldname, portal_type)
+            continue
+
+        if type_.handler is None:
+            continue
+        field = type_.handler(schema, type_.name, fieldname, properties)
+
+        for name, value in properties.items():
+            prop = PROPERTIES_MAPPING.get(name)
+            if prop is None:
+                continue
+
+            value = to_text(value)
+
+            # Convert TALES expressions with PFG specific methods
+            if name.startswith('fgT'):
+                value = convert_tales_expressions(value)
+
+            prop.handler(field, prop.name, value)
+
+        if portal_type == 'FieldsetStart':
+            schema = field
+
+    return etree.tostring(model, pretty_print=True)
+
+
+FIELDS_MODEL = b"""
+<model
+    xmlns="http://namespaces.plone.org/supermodel/schema"
+    xmlns:easyform="http://namespaces.plone.org/supermodel/easyform"
+    xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+    i18n:domain="collective.easyform">
+  <schema></schema>
+</model>
+"""

--- a/collective/easyform/migration/pfg.py
+++ b/collective/easyform/migration/pfg.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from collections import namedtuple
+from collective.easyform.migration.actions import actions_model
+from collective.easyform.migration.data import migrate_saved_data
+from collective.easyform.migration.fields import fields_model
+from plone.app.contenttypes.migration.field_migrators import (
+    migrate_richtextfield,  # noqa
+)
+from plone.app.contenttypes.migration.field_migrators import migrate_simplefield  # noqa
+from plone.app.contenttypes.migration.migration import ATCTContentMigrator
+from plone.app.contenttypes.migration.migration import migrate
+from plone.autoform.form import AutoExtensibleForm
+from plone.protect.interfaces import IDisableCSRFProtection
+from plone.supermodel import model
+from six import StringIO
+from z3c.form.button import buttonAndHandler
+from z3c.form.form import Form
+from zope import schema
+from zope.component.hooks import getSite
+from zope.interface import alsoProvides
+
+import logging
+import transaction
+
+
+logger = logging.getLogger('collective.easyform.migration')
+
+Field = namedtuple('Type', ['name', 'handler'])
+
+FIELD_MAPPING = {
+    'submitLabel': Field('submitLabel', migrate_simplefield),
+    'resetLabel': Field('resetLabel', migrate_simplefield),
+    'useCancelButton': Field('useCancelButton', migrate_simplefield),
+    'forceSSL': Field('forceSSL', migrate_simplefield),
+    'formPrologue': Field('formPrologue', migrate_richtextfield),
+    'formEpilogue': Field('formEpilogue', migrate_richtextfield),
+    'thanksPageOverride': Field('thanksPageOverride', migrate_simplefield),
+    'formActionOverride': Field('formActionOverride', migrate_simplefield),
+    'onDisplayOverride': Field('onDisplayOverride', migrate_simplefield),
+    'afterValidationOverride': Field('afterValidationOverride', migrate_simplefield),  # noqa
+    'headerInjection': Field('headerInjection', migrate_simplefield),
+    'checkAuthenticator': Field('CSRFProtection', migrate_simplefield),
+}
+
+
+class PloneFormGenMigrator(ATCTContentMigrator):
+    """Migrator for PFG to easyform"""
+
+    src_portal_type = 'FormFolder'
+    src_meta_type = 'FormFolder'
+    dst_portal_type = 'EasyForm'
+    dst_meta_type = None  # not used
+
+    def migrate_ploneformgen(self):
+        for pfg_field, ef_field in FIELD_MAPPING.items():
+            ef_field.handler(self.old, self.new, pfg_field, ef_field.name)
+        self.new.fields_model = fields_model(self.old)
+        self.new.actions_model = actions_model(self.old)
+
+        migrate_saved_data(self.old, self.new)
+
+    def migrate(self, unittest=0):
+        super(PloneFormGenMigrator, self).migrate()
+        logger.info(
+            'Migrated FormFolder %s',
+            '/'.join(self.new.getPhysicalPath()))
+
+
+class IMigratePloneFormGenFormSchema(model.Schema):
+    dry_run = schema.Bool(
+        title=u'Dry run',
+        required=True,
+        default=False,
+    )
+
+
+class MigratePloneFormGenForm(AutoExtensibleForm, Form):
+    label = u'Migrate PloneFormGen Forms'
+    ignoreContext = True
+    schema = IMigratePloneFormGenFormSchema
+
+    @buttonAndHandler(u'Migrate')
+    def handle_migrate(self, action):
+        data, errors = self.extractData()
+        if len(errors) > 0:
+            return
+
+        self.log = StringIO()
+        handler = logging.StreamHandler(self.log)
+        logger.addHandler(handler)
+        formatter = logging.Formatter(
+            '%(asctime)s %(levelname)s %(name)s %(message)s')
+        handler.setFormatter(formatter)
+
+        alsoProvides(self.request, IDisableCSRFProtection)
+        portal = getSite()
+        migrate(portal, PloneFormGenMigrator)
+
+        self.migration_done = True
+        if data.get('dry_run', False):
+            transaction.abort()
+            logger.info(u'PloneFormGen migration finished (dry run)')
+        else:
+            logger.info(u'PloneFormGen migration finished')
+
+    def render(self):
+        if getattr(self, 'migration_done', False):
+            return self.log.getvalue()
+        return super(MigratePloneFormGenForm, self).render()


### PR DESCRIPTION
Uses the existing migration and adjusts some imports and method calls to be compatible with 1.x.

It also sets the correct description for fieldsets (needs to be an attribute, not a property).