### PR TITLE
Fix translation of validation errors.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,10 +9,18 @@ Changelog
 
 .. towncrier release notes start
 
-2.2.1 (2020-11-17)
+2.2.2 (unreleased)
 ------------------
 
 Bug fixes:
+
+
+- Fix translations of validation errors.
+  [mathias.leimgruber] (#282)
+
+
+2.2.1 (2020-11-17)
+------------------
 
 
 - For increased security, in the modeleditor do not resolve entities, and remove processing instructions.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "2.2.2.dev0"
+version = "2.2.2"
 
 setup(
     name="collective.easyform",

--- a/src/collective/easyform/fields.py
+++ b/src/collective/easyform/fields.py
@@ -98,7 +98,7 @@ class FieldExtenderValidator(object):
                 vmethod = queryUtility(IFieldValidator, name=validator)
                 if not vmethod:
                     continue
-                res = vmethod(value)
+                res = vmethod(value, REQUEST=self.request)
                 if res:
                     raise Invalid(res)
         TValidator = getattr(efield, "TValidator", None)

--- a/src/collective/easyform/tests/testValidators.py
+++ b/src/collective/easyform/tests/testValidators.py
@@ -142,6 +142,27 @@ class TestBaseValidators(base.EasyFormTestCase):
         data, errors = form.extractData()
         self.assertEqual(len(errors), 1)
 
+    def test_validator_translation(self):
+        request = self.layer["request"]
+        request["LANGUAGE"] = "de"
+        request.LANGUAGE_TOOL.LANGUAGE = "de"
+
+        fields = get_schema(self.ff1)
+        IFieldExtender(fields["comments"]).validators = ["isInternationalPhoneNumber"]
+        set_fields(self.ff1, fields)
+
+        view = self.ff1.restrictedTraverse("view")
+        form = view.form_instance
+        form.update()
+
+        data, errors = form.extractData()
+        self.assertEqual(len(errors), 1)
+
+        expected_error_message = (
+            u"Validierung fehlgeschlagen (isInternationalPhoneNumber): "
+            u"'testcomments' Ist keine g\xfcltige internationale Telefonnummer")
+        self.assertEqual(errors[0].createMessage(), expected_error_message)
+
 
 class LoadFixtureBase(base.EasyFormTestCase):
     """ test validator in form outside of fieldset

--- a/src/collective/easyform/validators.py
+++ b/src/collective/easyform/validators.py
@@ -13,7 +13,7 @@ import six
 BAD_SIGNS = frozenset(["<a ", "www.", "http:", ".com", "https:"])
 
 
-def isValidEmail(value):
+def isValidEmail(value, **kwargs):
     """Check for the user email address.
     """
     if value is None:
@@ -23,7 +23,7 @@ def isValidEmail(value):
         raise EmailAddressInvalid
 
 
-def isCommaSeparatedEmails(value):
+def isCommaSeparatedEmails(value, **kwargs):
     """Check for one or more E-Mail Addresses separated by commas.
     """
     if value is None:
@@ -37,7 +37,7 @@ def isCommaSeparatedEmails(value):
             )
 
 
-def isChecked(value):
+def isChecked(value, **kwargs):
     if not (
         (isinstance(value, bool) and value)
         or (isinstance(value, six.string_types) and value == "1")
@@ -45,12 +45,12 @@ def isChecked(value):
         return _(u"Must be checked.")
 
 
-def isUnchecked(value):
+def isUnchecked(value, **kwargs):
     if not isChecked(value):
         return _(u"Must be unchecked.")
 
 
-def isNotLinkSpam(value):
+def isNotLinkSpam(value, **kwargs):
     if not value:
         return  # No value can't be SPAM
     # validation is optional and configured on the field
@@ -65,13 +65,13 @@ def update_validators():
     if validation and baseValidators:
 
         def method(name):
-            def validate(value):
+            def validate(value, **kwargs):
                 if value is None:
                     # Let the system for required take care of None values
                     return
                 if six.PY2 and isinstance(value, six.text_type):
                     value = value.encode("utf-8")
-                res = validation(name, value)
+                res = validation(name, value, **kwargs)
                 if res != 1:
                     return res
 


### PR DESCRIPTION
This PR fixes translations of validation errors.

All validators used from `Products.validation.validators` are passing ´kwargs` into `recursiveTranslate` from `Products.validation.i18n`, which checks for a "REQUEST" key and passes it to the translate method.

Thus this PR implements this and passes "REQUEST" if possible as additional kwarg.

I added a test to make sure translations are working now for validators, the local output seems fine:

```sh
> ./bin/test -t test_validator_translation
... truncated ...
Running collective.easyform.tests.base.collective.easyform:Integration tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.zope.Startup in 0.179 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.180 seconds.
  Set up plone.app.event.testing.PAEventLayer in 0.157 seconds.
  Set up plone.app.contenttypes.testing.PloneAppContenttypes in 0.090 seconds.
  Set up collective.easyform.tests.base.Fixture /Users/maethu/dotfiles/.buildout/eggs/zope.configuration-4.4.0-in 0.395 seconds.
  Set up collective.easyform.tests.base.collective.easyform:Integration in 0.000 seconds.
  Running:

  Ran 1 tests with 0 failures, 0 errors, 0 skipped in 0.092 seconds.
Tearing down left over layers:
  Tear down collective.easyform.tests.base.collective.easyform:Integration in 0.000 seconds.
  Tear down collective.easyform.tests.base.Fixture in 0.006 seconds.
  Tear down plone.app.contenttypes.testing.PloneAppContenttypes in 0.030 seconds.
  Tear down plone.app.event.testing.PAEventLayer in 0.006 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.062 seconds.
  Tear down plone.testing.zope.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.000 seconds.

```

Once merged I create a PR for the master branch too. 