### PR TITLE
Implement option to download the saved data as XLSX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,8 +9,15 @@ Changelog
 
 .. towncrier release notes start
 
-2.2.2 (unreleased)
+2.3.0 (unreleased)
 ------------------
+
+New features: 
+
+
+- Download XLSX version of saved data.
+  [mathias.leimgruber] (#283)
+
 
 Bug fixes:
 

--- a/README.rst
+++ b/README.rst
@@ -163,6 +163,24 @@ To do that, edit the form, go to the "Thanks page" settings, disable "Show all f
 Likewise for the mailer: open the form actions via the Actions toolbar menu and edit the mailer settings accordingly.
 
 
+Download XLSX from savedata adapter support
+===========================================
+
+Install ``collective.easyform`` with the  ``downloadxlsx`` extra:
+
+.. code-block:: shell
+
+    [buildout]
+
+    ...
+
+    eggs =
+        collective.easyform [downloadxlsx]
+
+
+This gives you the option to download the saved data as XLSX using openpyxl to generate the XLSX file.
+
+
 Actions
 =======
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "2.2.2"
+version = "2.3.0"
 
 setup(
     name="collective.easyform",
@@ -53,6 +53,7 @@ setup(
         # -*- Extra requirements: -*-
     ],
     extras_require={
+        "downloadxlsx": ["openpyxl"],
         "recaptcha": ["plone.formwidget.recaptcha"],
         "norobots": ["collective.z3cform.norobots"],
         "ploneformgen": ["Products.PloneFormGen",],

--- a/src/collective/easyform/config.py
+++ b/src/collective/easyform/config.py
@@ -2,9 +2,17 @@
 from Products.CMFPlone.utils import safe_unicode
 
 import os
+import pkg_resources
 
 
 this_path = os.path.dirname(__file__)
+
+
+try:
+    pkg_resources.get_distribution('openpyxl')
+    HAS_XLSX_SUPPORT = True
+except pkg_resources.DistributionNotFound:
+    HAS_XLSX_SUPPORT = False
 
 
 EDIT_TALES_PERMISSION = "collective.easyform.EditTALESFields"

--- a/src/collective/easyform/locales/collective.easyform.pot
+++ b/src/collective/easyform/locales/collective.easyform.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -25,15 +25,15 @@ msgstr ""
 msgid "Action type"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr ""
 
@@ -54,28 +54,19 @@ msgstr ""
 msgid "Define form fields"
 msgstr ""
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr ""
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr ""
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr ""
 
@@ -83,15 +74,15 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr ""
 
@@ -99,28 +90,24 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr ""
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr ""
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr ""
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr ""
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr ""
@@ -129,15 +116,15 @@ msgstr ""
 msgid "Posting Date/Time"
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr ""
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr ""
 
@@ -145,7 +132,7 @@ msgstr ""
 msgid "Saved data"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr ""
 
@@ -154,16 +141,8 @@ msgstr ""
 msgid "This Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
-msgstr ""
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr ""
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
 msgstr ""
 
 #: collective/easyform/interfaces/fields.py:141
@@ -171,7 +150,7 @@ msgid "Validators"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr ""
 
@@ -181,12 +160,12 @@ msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr ""
 
@@ -196,48 +175,48 @@ msgid "description_server_side_text"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr ""
 
@@ -246,91 +225,91 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr ""
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr ""
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr ""
 
@@ -340,36 +319,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr ""
 
@@ -379,7 +358,7 @@ msgstr ""
 msgid "help_registry_items"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -394,55 +373,55 @@ msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
@@ -457,27 +436,27 @@ msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr ""
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr ""
 
@@ -486,7 +465,7 @@ msgstr ""
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -501,46 +480,46 @@ msgid "help_userfield_validators"
 msgstr ""
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr ""
 
@@ -550,12 +529,12 @@ msgid "label_downloadformat_text"
 msgstr ""
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr ""
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr ""
 
@@ -565,92 +544,92 @@ msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr ""
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr ""
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr ""
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr ""
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr ""
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr ""
 
@@ -660,67 +639,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr ""
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr ""
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr ""
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr ""
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr ""
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr ""
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr ""
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -735,27 +719,27 @@ msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr ""
 
@@ -765,32 +749,32 @@ msgid "label_server_side_text"
 msgstr ""
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr ""
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr ""
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr ""
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr ""
 
@@ -805,32 +789,32 @@ msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr ""
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr ""
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr ""
 
@@ -840,7 +824,7 @@ msgid "label_tvalidator_text"
 msgstr ""
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr ""
 
@@ -850,29 +834,34 @@ msgid "label_usecolumnnames_text"
 msgstr ""
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr ""
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
+msgstr ""
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: 2017-01-20 09:48+0000\n"
 "Last-Translator: Johannes Raggam <raggam-nl@adm.at>\n"
 "Language-Team: \n"
@@ -24,15 +24,15 @@ msgstr "${items} Eingabe(n) gespeichert."
 msgid "Action type"
 msgstr "Art der Aktion"
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr "Aktionsmodell"
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr "Eine neue Aktion hinzufügen"
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr "Adressierung"
 
@@ -53,28 +53,19 @@ msgstr "Formular Aktionen bearbeiten"
 msgid "Define form fields"
 msgstr "Formular Felder bearbeiten"
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr "EasyForm deinstallieren"
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr ""
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr "Aktion '${fieldname}' bearbeiten"
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr "XML Aktionsmodell bearbeiten"
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr "XML Feldmodell bearbeiten"
 
@@ -82,15 +73,15 @@ msgstr "XML Feldmodell bearbeiten"
 msgid "Export"
 msgstr "Exportieren"
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr "Feldmodell"
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr "Formular importiert."
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr "Kopfzeilen"
 
@@ -98,28 +89,24 @@ msgstr "Kopfzeilen"
 msgid "Import"
 msgstr "Importieren"
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr "Installieren der collective.easyform Erweiterung"
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr "Links sind nicht erlaubt."
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Muss eine gültige Liste von E-Mail Adressen sein (getrennt durch Kommas)."
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr "Erforderliche Eingabe fehlt."
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr "Darf nicht angewählt sein."
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr "Anpassungen"
@@ -128,15 +115,15 @@ msgstr "Anpassungen"
 msgid "Posting Date/Time"
 msgstr "Datum/Zeit des Eintrags"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr "Weiterleiten nach"
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr "HTML Bezeichnung"
 
@@ -144,7 +131,7 @@ msgstr "HTML Bezeichnung"
 msgid "Saved data"
 msgstr "Gespeicherte Daten"
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr "Danke-Seite"
 
@@ -153,24 +140,16 @@ msgstr "Danke-Seite"
 msgid "This Fields are available for your forms."
 msgstr "Diese Felder stehen für das Formular zur Verfügung."
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
 msgstr "Traversieren nach"
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr "Deinstallieren der collective.easyform Erweiterung"
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
-msgstr ""
 
 #: collective/easyform/interfaces/fields.py:141
 msgid "Validators"
 msgstr "Überprüfungen"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr "Zurücksetzen"
 
@@ -180,12 +159,12 @@ msgid "default_submitLabel"
 msgstr "Absenden"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr "Danke für Ihren Beitrag."
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr "Vielen Dank"
 
@@ -195,48 +174,48 @@ msgid "description_server_side_text"
 msgstr "Das Feld im Request an den Server übermitteln. Es ist im Formular nicht editierbar und wird auch dort nicht angezeigt."
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} Kopfzeile"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr "Dieses Feld erlaubt die Veränderung der 'Standard' Fieldset Bezeichnung."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr "Dieser Text wird nach den Formular Feldern angezeigt."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr ""
 
@@ -245,91 +224,91 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr "Zusätzliche E-Mail-Kopfzeilen. Kopfzeilen nur gemäss RFC822 setzen."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr "E-Mail Adressen, die eine BCC (Blindkopie) erhalten sollen."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr "Text der als Fusszeilen am Ende der E-Mail durch zwei Minuszeichen abgetrennt angehängt wird."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr "Text, der in der E-Mail nach der Feldliste angezeigt wird."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr "Text, der in der E-Mail vor der Feldliste angezeigt wird."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr "E-Mail Adressen, die eine CC (Kopie) erhalten sollen."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr "Empfänger E-Mail Adresse"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr "Vor- und Nachname des Empfängers"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr "Betreff Zeile der Nachricht. Diese wird verwendet, falls kein 'subject' Feld definiert wird oder dieses Feld leer ist."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr ""
 
@@ -339,36 +318,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr "Dieser Text wird über dem Formular angezeigt."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr ""
 
@@ -378,7 +357,7 @@ msgstr ""
 msgid "help_registry_items"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -393,55 +372,55 @@ msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rolle, unter der das Script ausgeführt werden soll."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr "Wähle die Feldnamen, deren Eingaben in der Danke-Seite angezeigt werden sollen."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
@@ -456,27 +435,27 @@ msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr "Wird in der Danke-Seite verwendet."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr "Dieser Text wird in der Danke-Seite nach den Feldern angezeigt."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr "Dieser Text wird in der Danke-Seite vor den Feldern angezeigt."
 
@@ -485,7 +464,7 @@ msgstr "Dieser Text wird in der Danke-Seite vor den Feldern angezeigt."
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -500,46 +479,46 @@ msgid "help_userfield_validators"
 msgstr "Wáhle die Validatoren für diese Feld aus."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr "Wähle irgendwelche HTTP-Header, die in die E-Mail als 'X-' Kopfzeilen eingefügr werden sollen.' "
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr "Importieren"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr "Script nach der Validierung"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr "Script zum Formular Setup"
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr "BCC Ausdruck"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr "CC Ausdruck"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr "CSRF Schutz"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr "Eigene 'Standard' Fieldset Bezeichnung"
 
@@ -549,12 +528,12 @@ msgid "label_downloadformat_text"
 msgstr "Download Format"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr "Epilog des Formulars"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr "Ausfúhrungs Bedingung"
 
@@ -564,92 +543,92 @@ msgid "label_field_widget"
 msgstr "Feld Widget"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr "Erzwinge SSL Verbindung"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr "Verwandeln von Fieldsets in Reiter"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr "Eigene Formular Aktion"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr "Zusätzliche Kopfzeilen"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC Empfänger"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr "E-Mail-Text (Signatur)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr "E-Mail-Text (nach gestellt)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr "E-Mail-Text (voran gestellt)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr "E-Mail-Text Template"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr "E-Mail Format"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr "CC Empfänger"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr "Empfänger E-Mail Adresse"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr "Empfänger Vor- und Nachname"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr "entnehme Reply-To aus"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr "Betreff"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr "entnehme Betreff aus"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr "entnehme Empfänger E-Mail aus"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr "Zusätzliche Tags in HTML-Head einfügen"
 
@@ -659,67 +638,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr "Leere Felder einbinden"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr "Bezeichnung"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr "Leere Felder einbinden"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr "Alle Felder einbinden"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr "Zeige Antworten"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr "Formular Methode"
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr "Formular Prolog"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr "Empfänger Ausdruck"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr "Beschriftung Zurücksetzen Knopf"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr "Beschriftung HTML"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -734,27 +718,27 @@ msgid "label_savefields_text"
 msgstr "Gespeicherte Felder"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script E-Mail Text"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy Rolle"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr "Ausdruck Absender"
 
@@ -764,32 +748,32 @@ msgid "label_server_side_text"
 msgstr "Server-seitige Variable"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr "Zeige alle Felder"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr "Zeige Reset Knopf"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr "Zeige Antworten"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr "Ausdruck Betreff"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr "Beschriftung Absenden Knopf"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr "Eigener Absenden Knopf"
 
@@ -804,32 +788,32 @@ msgid "label_tenabled_text"
 msgstr "Ausdrücke einschalten"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr "Danke-Seite Zusammenfassung"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr "Danke-Seite Epilog"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr "Eigene Erfolgsaktion"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr "Art der eigenen Erfolgsaktion "
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr "Danke-Seite Prolog"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr "Title der Danke-Seite"
 
@@ -839,7 +823,7 @@ msgid "label_tvalidator_text"
 msgstr "Eigene Validierung"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr "Seite-Verlassen Schutz"
 
@@ -849,29 +833,34 @@ msgid "label_usecolumnnames_text"
 msgstr "Spaltennamen inkludieren"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Headers"
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr "Der Filetype ${ftype} ist als Upload nicht erlaubt!"
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr "Die hochgeladene Datei ist grösser als ${size} Bytes!"
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr "Komma getrennte Werte (CSV)"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr "Datum und Zeit an dem das Formular abgeschickt wurde"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
 msgstr "Werte durch Tabulatoren getrennt (TSV)"
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
+msgstr ""

--- a/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,15 +22,15 @@ msgstr ""
 msgid "Action type"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr ""
 
@@ -51,28 +51,19 @@ msgstr ""
 msgid "Define form fields"
 msgstr ""
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr ""
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr ""
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr ""
 
@@ -80,15 +71,15 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr ""
 
@@ -96,28 +87,24 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr ""
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr ""
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr ""
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr ""
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr ""
@@ -126,15 +113,15 @@ msgstr ""
 msgid "Posting Date/Time"
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr ""
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr ""
 
@@ -142,7 +129,7 @@ msgstr ""
 msgid "Saved data"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr ""
 
@@ -151,16 +138,8 @@ msgstr ""
 msgid "This Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
-msgstr ""
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr ""
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
 msgstr ""
 
 #: collective/easyform/interfaces/fields.py:141
@@ -168,7 +147,7 @@ msgid "Validators"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr ""
 
@@ -178,12 +157,12 @@ msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr ""
 
@@ -193,48 +172,48 @@ msgid "description_server_side_text"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr ""
 
@@ -243,91 +222,91 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr ""
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr ""
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr ""
 
@@ -337,36 +316,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr ""
 
@@ -376,7 +355,7 @@ msgstr ""
 msgid "help_registry_items"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -391,55 +370,55 @@ msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
@@ -454,27 +433,27 @@ msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr ""
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr ""
 
@@ -483,7 +462,7 @@ msgstr ""
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -498,46 +477,46 @@ msgid "help_userfield_validators"
 msgstr ""
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr ""
 
@@ -547,12 +526,12 @@ msgid "label_downloadformat_text"
 msgstr ""
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr ""
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr ""
 
@@ -562,92 +541,92 @@ msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr ""
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr ""
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr ""
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr ""
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr ""
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr ""
 
@@ -657,67 +636,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr ""
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr ""
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr ""
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr ""
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr ""
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr ""
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr ""
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -732,27 +716,27 @@ msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr ""
 
@@ -762,32 +746,32 @@ msgid "label_server_side_text"
 msgstr ""
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr ""
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr ""
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr ""
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr ""
 
@@ -802,32 +786,32 @@ msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr ""
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr ""
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr ""
 
@@ -837,7 +821,7 @@ msgid "label_tvalidator_text"
 msgstr ""
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr ""
 
@@ -847,29 +831,34 @@ msgid "label_usecolumnnames_text"
 msgstr ""
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr ""
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
+msgstr ""
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: 2018-11-09 09:59+0100\n"
 "Last-Translator: Mikel Larreategi <mlarreategi@codesyntax.com>\n"
 "Language-Team: \n"
@@ -27,15 +27,15 @@ msgstr ""
 msgid "Action type"
 msgstr "Tipo de Acción"
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr "Modelo de Acción"
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr "Añadir nueva acción"
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr "Direcciónes"
 
@@ -56,28 +56,19 @@ msgstr "Configurar acciones"
 msgid "Define form fields"
 msgstr "Configurar campos"
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr "EasyForm (desinstalar)"
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr "EasyForm testing"
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar acción '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr "Editar XML de Modelo de Acción"
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr "Editar XML de Modelo de Campos"
 
@@ -85,15 +76,15 @@ msgstr "Editar XML de Modelo de Campos"
 msgid "Export"
 msgstr "Exportar"
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr "Modelo de campos"
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr "Formulario importado."
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr "Cabeceras"
 
@@ -101,28 +92,24 @@ msgstr "Cabeceras"
 msgid "Import"
 msgstr "Importar"
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr "Instala el paquete collective.easyform"
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr "No se permiten enlaces."
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Tiene que ser una lista de dirección de correo electrónico válidas (separada por comas)."
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr "Tiene que estar seleccionado."
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr "No tiene que estar seleccionado."
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr "Personalización"
@@ -131,15 +118,15 @@ msgstr "Personalización"
 msgid "Posting Date/Time"
 msgstr "Día y hora del envío"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr "Redirigir a"
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr "Limpiar"
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr "Etiqueta de texto enriquecido"
 
@@ -147,7 +134,7 @@ msgstr "Etiqueta de texto enriquecido"
 msgid "Saved data"
 msgstr "Datos almacenados"
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr "Página de agradecimiento"
 
@@ -156,24 +143,16 @@ msgstr "Página de agradecimiento"
 msgid "This Fields are available for your forms."
 msgstr "Estos campos están disponibles para tus formularios"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
 msgstr "Ir a"
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr "Desinstalar el paquete collective.easyform"
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
-msgstr "Solo se utiliza para pruebas automáticas (tests)"
 
 #: collective/easyform/interfaces/fields.py:141
 msgid "Validators"
 msgstr "Validadores"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr "Limpiar"
 
@@ -183,12 +162,12 @@ msgid "default_submitLabel"
 msgstr "Enviar"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr "Gracias por su envío"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr "Gracias"
 
@@ -198,48 +177,48 @@ msgid "description_server_side_text"
 msgstr "Activar este campo para que su valor se inyecte automáticamente en la petición, se pueda utilizar por alguna acción, no sea expuesto al cliente y éste no lo pueda modificar."
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "Cabecera ${name}"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr "Una expresión TALES que será llamada después que el formulario se valide, pero antes de llamar un adaptador de acción (si hay alguno) o mostrar la página de agradecimiento. Los datos introducidos en el formulario estará en el diccionario \\\"request.form\\\". Déjela vacía si no la necesita. El uso más común de este campo es para llamar un script python para limpiar la entrada del formulario o para ejecutar una acción alternativa. Cualquier valor devuelto por la expresión se ignorará. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr "Una expresión TALES que será llamada cuando el formulario se muestra. Déjela vacía si no la necesita. El uso más común de este campo es para llamar un script python que asigna valores por defecto para múltiples campos pre-populando el request.form. Cualquier valor devuelto por la expresión se ignorará. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr "Una expresión TALES que devolverá el listado de correos electrónicos que sobreescribirán el valor del campo BCC. Ten cuidado al utilizar datos del request sin validar para esto. Déjela vacía si no la necesita. La expresión deberá devolver una lista de cadenas de texto. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr "Una expresión TALES que devolverá el listado de correos electrónicos que sobreescribirán el valor del campo CC. Ten cuidado al utilizar datos del request sin validar para esto. Déjela vacía si no la necesita. La expresión deberá devolver una lista de cadenas de texto. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr "Activar para utilizar la protección Cross-Site Request Forgery. Solo se permitirán peticiones HTTP POST."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr "Con este campo puedes modificar la etiqueta del conjunto de campos por defecto."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr "Este texto se mostrará después de los campos del formulario."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr "Una expresión TALES que será evaluada para decidir si se ejecutará esta acción o no. Déjela vacía si no la necesita. La expresión deberá devolver un valor booleano; return True para que la acción se ejecute. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
@@ -248,91 +227,91 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr "Activar para que el formulario se muestre en la versión con SSL activado (https://) si se accede a él desde una versión no-SSL (http://). Para que esta redirección funcione adecuadamente, el servidor web tiene que estar configurado para servir peticiones con el protocolo HTTPS en el puerto 443 y redirigir las peticiones a Zope."
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr "Utiliza este campo para sobreescribir el valor del atributo \"action\" del formulario. Especifica la URL a la que se enviarán los datos. Esta configuración hará que no se ejecute la validación, las acciones configuradas y la página de agradecimiento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr "Cabeceras adicionales del correo electrónico enviado. Utilizar solo cabeceras RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr "Correos electrónicos que recibirán una copia oculta (BCC, CCO)"
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr "Texto que se añade en el pie de página."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr "Texto que se añade después los campos del cuerpo de texto."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr "Texto que se añade antes de los campos del cuerpo de texto."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr "Esta es una plantilla Zope Page Templates que se utiliza para crear el texto del correo electrónico. No necesitas modificarla, pero si sabes TAL puedes personalizar los mensajes."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr "Establece el tipo MIME del cuerpo del mensaje. Cambiar solo si se sabe que está haciendo. Déjalo vacío para el comportamiento habitual."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr "Correos electrónicos que recibirán una copia del mensaje (CC)."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr "Correo electrónico del receptor"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr "Nombre del receptor"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor de la cabecera \"Reply-To\". NOTA: Deberías activar la validación para verificar que el campo contenga una dirección de correo electrónico."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr "Asunto del mensaje. Se utiliza si no eliges un campo para extraer el asunto o si el valor de dicho campo es vacío."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor del asunto del mensaje."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor de la cabecera \"To\", es decir, a quién se enviará el formulario. Si seleccionas algo que no sea \"None\", esto sobreescribirá el valor del \"Correo electrónico del receptor. Cuidado al utilizar valores introducidos por el usuario que no se hayan validado o limpiado."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr "Este campo permite introducir código en la cabecera HTML. El uso más habitual es para introducir CSS o JavaScript. Especificar una expresión TALES que devuelva una cadena de caracteres. La cadena se incorporará tal cual al HTML. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
@@ -342,36 +321,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr "Seleccionar para mostrar los títulos de los campos que se han dejado vacíos. Si no está seleccionado, los campos vacíos no se mostrarán en el listado."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr "Seleccionar para mostrar los títulos de los campos que se han dejado vacíos en el mensaje. Si no está seleccionado, los campos vacíos no se mostrarán en el mensaje."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr "Seleccionar para incluir todos los campos (excepto los campos de etiqueta y los de archivo). Si está seleccionado, la selección del campo siguiente se ignorará."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr "Seleccionar los campos que se incluirán en el mensaje."
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr "Este texto se mostrará antes que los campos del formulario"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor del campo del correo electrónico del receptor del mensaje. Cuidado al utilizar datos no validados del formulario. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
@@ -381,7 +360,7 @@ msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor
 msgid "help_registry_items"
 msgstr "Seleccionar los elementos del registro que quieres modificar"
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -396,55 +375,55 @@ msgid "help_savefields_text"
 msgstr "Seleccionar los campos a guardar. Si está vacío se guardarán todos."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Escribir el script aquí."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rol con el que se ejecutará el script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr "Seleccionar los datos adicionales a guardar junto con los datos del formulario."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr "Seleccionar para mostrar los datos de todos los campos (salvo los campos de etiqueta y de archivo). Si está seleccionado, la selección del campo siguiente se ignorará."
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr "Seleccionar los campos que se mostrarán en la página de agradecimiento."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor del campo asunto. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr "Este campo permite sobreescribir el texto del botón de envío del formulario. El uso más habitual es cambiar la etiqueta según algún parámetro de la petición. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
@@ -459,27 +438,27 @@ msgid "help_tenabled_text"
 msgstr "Una expresión TALES que se evaluará para decidir si el campo está activo o no. La expresión deberá evaluarse como True si el campo se tiene que incluir en el formulario y False si no debe ser incluido. Déjela vacía si no la necesita y en ese caso el campo se incluirá. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr "Se utiliza en la página de agradecimiento"
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr "El texto se mostrará tras los datos del formulario."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr "Este campo se utiliza en lugar de la página de agradecimiento para determinar a dónde redirigir al usuario después de la acción (si hay alguna). Normalmente se utilizará para una plantilla o script personalizado. Déjela vacía si no la necesita. El valor debe ser una acción de CMFFormController y el argumento (por ejemplo: \"redirect_to\" ó \"traverse_to\" y la expresión TALES correspondiente. Por ejemplo: redirect_to: string:thanks-page."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr "Este campo se utiliza en lugar de la página de agradecimiento para determinar a dónde redirigir al usuario después de la acción (si hay alguna). Normalmente se utilizará para una plantilla o script personalizado. Déjela vacía si no la necesita. El valor debe ser una acción de CMFFormController y el argumento (por ejemplo: \"redirect_to\" ó \"traverse_to\" y la expresión TALES correspondiente. Por ejemplo: redirect_to: string:thanks-page."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr "Este texto se mostrará antes de los datos del formulario."
 
@@ -488,7 +467,7 @@ msgstr "Este texto se mostrará antes de los datos del formulario."
 msgid "help_tvalidator_text"
 msgstr "Una expresión TALES que se evaluará al validar el formulario. Utilizar 'value' para realizar la validación, que contendrá el dato introducir. Devolver False si es válido; si no devolver el mensaje de error. Por ejemplo: python:test(value=='casa', False, 'tiene que introducir casa') requerirá que el valor introducio sea 'casa'. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -503,46 +482,46 @@ msgid "help_userfield_validators"
 msgstr "Seleccionar los validadores de este campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr "Seleccionar cualquier elemento de las cabeceras HTTP que se quiera introducir como cabecera X-header del mensaje."
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr "Importar"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr "Script post-validación"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de preparación del formulario"
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr "Expresión CCO/BCC"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr "Expressión CC"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr "Protección CSRF"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr "Etiqueta personalizada del conjunto de campos por defecto"
 
@@ -552,12 +531,12 @@ msgid "label_downloadformat_text"
 msgstr "Formato de la descarga"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr "Epílogo del formulario"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr "Condición de ejecución"
 
@@ -567,92 +546,92 @@ msgid "label_field_widget"
 msgstr "Widget del campo"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr "Forzar conexión SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr "Convertir conjuntos de campos a pestañas"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr "Acción personalizada"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr "Cabeceras adicionales"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr "Receptores CCO/BCC"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr "Cuerpo (firma)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr "Cuerpo (añadido después)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr "Cuerpo (añadido antes)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr "Plantilla del mensaje"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr "Formato del mensaje"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr "Receptores CC"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr "Correo electrónico del receptor"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nombre del receptor"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr "Extraer Reply-To"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr "Asunto"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr "Extraer Asunto"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr "Extraer Receptor"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr "Inyección de cabeceras"
 
@@ -662,67 +641,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr "Incluir valores vacíos"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr "Etiqueta"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr "Incluir vacíos"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr "Incluir todos los campos"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr "Mostrar respuestas"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr "Método del formulario"
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr "Prólogo del formulario"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr "Expresión del receptor"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr "Etiqueta del botón reset"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr "Etiqueta de texto enriquecido"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -737,27 +721,27 @@ msgid "label_savefields_text"
 msgstr "Campos guardados"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Cuerpo del script"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy rol"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr "Expresión del remitente"
 
@@ -767,32 +751,32 @@ msgid "label_server_side_text"
 msgstr "Variable del Servidor"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr "Mostrar todos los campos"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr "Mostrar botón reset"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr "Mostrar respuestas"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr "Expresión de Asunto"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr "Etiqueta del botón Enviar"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr "Etiqueta del botón Enviar personalizada"
 
@@ -807,32 +791,32 @@ msgid "label_tenabled_text"
 msgstr "Expresión habilitante"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr "Descripción del agradecimiento"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr "Epílogo del agradecimiento"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr "Acción personalizada"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr "Tipo de acción personalizada"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr "Prólogo del agradecimiento"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr "Título del agradecimiento"
 
@@ -842,7 +826,7 @@ msgid "label_tvalidator_text"
 msgstr "Validador personalizado"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr "Protección de descarga"
 
@@ -852,29 +836,34 @@ msgid "label_usecolumnnames_text"
 msgstr "Incluir nombres de columnas"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr "Cabeceras HTTP"
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr "Archivo no permitido"
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr "Archivo demasiado grande"
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr "Archivo CSV (separado por comas)"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr "Día/Hora del envío"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
 msgstr "Archivo TSV (separado por tabulaciones)"
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
+msgstr ""

--- a/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: 2017-10-22 16:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -24,15 +24,15 @@ msgstr "${items} elementu gorde dira"
 msgid "Action type"
 msgstr "Akzio mota"
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr "Akzioen eredua"
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr "Akzio berria gehitu"
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr "Helbideak"
 
@@ -53,28 +53,19 @@ msgstr "Formularioaren akzioak konfiguratu"
 msgid "Define form fields"
 msgstr "Formularioaren eremuak konfiguratu"
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr "EasyForm (kendu)"
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr "EasyForm testing"
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr "'${fieldname}' akzioa aldatu"
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr "Akzioen XML eredua editatu"
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr "Eremuen XML eredua editatu"
 
@@ -82,15 +73,15 @@ msgstr "Eremuen XML eredua editatu"
 msgid "Export"
 msgstr "Esportatu"
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr "Eremuen eredua"
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr "Formulario ondo inportatu da."
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr "Goiburukoak"
 
@@ -98,28 +89,24 @@ msgstr "Goiburukoak"
 msgid "Import"
 msgstr "Inportatu"
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr "collective.easyform instalatu"
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr "Ez dira loturak onartzen."
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Eposta helbideen zerrenda bat izan behar da (komarekin banatuta)."
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr "Aukeratuta egon behar da"
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr "Ezin da aukeratuta egon"
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr "Gainidazketak"
@@ -128,15 +115,15 @@ msgstr "Gainidazketak"
 msgid "Posting Date/Time"
 msgstr "Bidalketaren data/ordua"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr "Berbideratu (redirect_to)"
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr "Garbitu"
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr "Etiketa aberatsa"
 
@@ -144,7 +131,7 @@ msgstr "Etiketa aberatsa"
 msgid "Saved data"
 msgstr "Gordetako datuak"
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr "Eskertza-orria"
 
@@ -153,24 +140,16 @@ msgstr "Eskertza-orria"
 msgid "This Fields are available for your forms."
 msgstr "Eremu hauek gehitu daitezke formularioetan."
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
 msgstr "Joan (traverse_to)"
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr "collective.easyform kendu"
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
-msgstr "Testak exekutatzeko bakarrik"
 
 #: collective/easyform/interfaces/fields.py:141
 msgid "Validators"
 msgstr "Balidadoreak"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr "Garbitu"
 
@@ -180,12 +159,12 @@ msgid "default_submitLabel"
 msgstr "Bidali"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr "Eskerrik asko bidalketagatik"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr "Eskerrik asko"
 
@@ -195,48 +174,48 @@ msgid "description_server_side_text"
 msgstr "Aktibatuz gero, eremu honen balioa akzioek erabiliko dute bakarrik eta ez da formularioan erakutsiko."
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} goiburukoa"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr "Formularioa ondo balidatu ostean baina edozein akzio exekutatu edo eskertza orrialde erakutsi baino lehen exekutatuko den TALES espresioa. Formularioan sartutako datuak request.form-en egongo dira. Utzi hutsik ez baduzu behar. Eremu honen erabilpen arruntena, formularioko datuak garbitzeko edo akzio gisa erabiliko den python script bati deitzea da. Espresioak itzulitako edozein erantzun ez da kontuan hartuko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr "Formularioa erakustean exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Eremu honen erabilpen arruntena formularioaren eremuen defektuzko balioak ezarriko dituen python script bati deitzea da, horretarako request.form-en balioak ezarriko dituelarik. Espresioak itzulitako edozein erantzun ez da kontuan hartuko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr "BCC zerrendaren balioak gainidatziko dituen TALES espresioa. Kontuz honetarako balioztatu gabeko edozein balio erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-kate zerrenda bat itzuli behar du. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr "CC zerrendaren balioak gainidatziko dituen TALES espresioa. Kontuz honetarako balioztatu gabeko edozein balio erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-kate zerrenda bat itzuli behar du. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr "Aktibatuta badago CSRF edo Cross-Site-Request-Forgery deritzon babesa erabiltzen du. Izan kontuan kasu horretan HTTP POST erako akzioak bakarrik onartuko direla."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr "Eremu honek defektuzko eremu-multzoaren etiketa aldatzen uzten dizu."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr "Formularioaren eremuen ostean agertuko den testua."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr "Akzio hau exekutatu ala ez erabakitzeko exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak balio boolear bat itzuli behar du; True itzuli akzioa exekutatzeko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
@@ -245,91 +224,91 @@ msgid "help_field_widget"
 msgstr " "
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr "Aktibatuta badago, automatikoki HTTPS darabilen helbidera berbideratuko da formularioa (https://). Ondo funtzionatzeko aurrez web zerbitzaria konfiguratu behar duzu HTTPS protokoloarekin funtzionatu dezan eta eskaerak Plone zerbitzari bidera ditzan."
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr " "
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr "Formularioaren 'action' atributua gainidazteko erabili eremu hau. Idatzi hemen formularioaren datuak zein URLtara bidali behar diren. Hau erabiliz gero formularioaren balidazioa, eta konfiguratutako akzioak eta eskertza-orriak ez dira kontuan hartuko."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr "Eposta mezuan gehitu beharreko goiburu gehigarriak. RFC822rekin bat datozen goiburuak bakarrik erabili."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr "BCC kopia ezkutu bat jasoko duten helbideak."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr "Mezuaren oinean gehituko den testua, mezuaren azpian agertuko da marradun lerro baten ostean."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr "Mezuaren gorputzean dauden eremuei ondoren gehituko zaien testua"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr "Mezuaren gorputzean dauden eremuei aurretik gehituko zaien testua"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr "Mezuaren gorputza sortzeko erabiliko den txantilioia (ZPT). Ez duzu zertan aldatu, baina TAL baldin badakizu, bidalitako mezuaren itxura osorik pertsonalizatu dezakezu."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr "Mezuaren mime-type-a zehaztu. Zer egiten ari zaren badakizu bakarrik aldatu. Utzi hutsik defektuzko portaerarako."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr "CC kopia bat jasoko duten helbideak."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr "Jasotzailearen eposta helbidea"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr "Jasotzailearen izena"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr "Reply-To goiburukoaren balioa ateratzeko formularioko eremua aukeratu. OHARRA: aukeratu duzun eremuarentzat eposta balidatzailea aktibatzea gomendatzen dizugu"
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr "Mezuaren gaia. Hauxe erabiliko da ez baduzu gai eremua erabili edo eremua hutsik badago"
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr "Mezuaren gaia formularioko zein eremutatik atera aukeratu."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr "To goiburuaren balioa (mezuaren jasotzailea) zein eremutatik atera aukeratu. \"None\" ez den beste zerbait aukeratzen baduzu, honek \"Jasotzaileak\" goiko ezarpena gainidatziko du. Kontuz ibili balidatu gabeko balioak onartzearekin."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr "HTML goiburuan edukia txertatu dezakezu. Erabilpen arruntena CSS eta JavaScripta txertatzea izaten da. Idatzi testu-kate bat itzuliko duen TALES espresio bat. Testu katea interpretatu gabe txertatuko da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
@@ -339,36 +318,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr "Aukeratuta badago baliorik jaso ez duten formularioko eremuen etiketak erakutsi egingo dira. "
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr "Aukeratuta badago baliorik jaso ez duten formularioko eremuen etiketak erakutsi egingo dira bidalitako epostan. "
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr "Aukeratuta badago eremu guztien balioak (etiketak eta fitxategiak izan ezik) sartuko dira eposta mezuan. Aukeratzen baduzu, beheko kutxako aukerak ez dira kontuan hartuko."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr "Aukeratu zein eremuren balioak bidali nahi dutuzun eposta mezuan."
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr " "
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr "Formularioko eremuen aurretik agertuko den testua."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr "Jasotzailearen epostaren balioa gainidazteko exekutatuko den TALES espresioa. Kontuz ibili balidatu gabeko balioak erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-katea bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
@@ -378,7 +357,7 @@ msgstr "Jasotzailearen epostaren balioa gainidazteko exekutatuko den TALES espre
 msgid "help_registry_items"
 msgstr "Aldatu nahi dituzun erregistroko balioak aukeratu."
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr " "
 
@@ -393,55 +372,55 @@ msgid "help_savefields_text"
 msgstr "Aukeratu zein balio gorde nahi dituzun. Hutsik uzten baduzu, eremu guztien balioak gordeko dira."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Idatzi hemen zuren scripta"
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Scripta zein rolekin exekutatuko den."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr "\"From\" (bidaltzailea) goiburukoaren balioa gainidazteko erabiliko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr "Aukeratuta badago eremu guztien balioak erakutsiko ditu (etiketak eta fitxategiak izan ezik). Aukeratzen baduzu, beheko kutxako aukerak ez dira kontuan hartuko."
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr " "
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr "Aukeratu zein eremuren balioak erakutsi nahi dituzun eskertza-orrian."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr "Epostaren gaia gainidazteko exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr " "
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr "Bidalketa botoiaren etiketa aldatzeko TALES espresioa. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
@@ -456,27 +435,27 @@ msgid "help_tenabled_text"
 msgstr "Eremua aktibo egongo den edo ez erabakitzeko formularioa erakustean exekutatuko den TALES espresioa. Espresioak True balio boolearra itzuli beharko du eremua formularioan erakustarazi nahi baduzu, aldiz, False ez bada erakutsi behar. Utzi hutsik behar ez baduzu: horrela eremua erakutsi egingo da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr "Eskertza-orrian erabiliko da."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr "Eremuen balioen ostean erakutsiko den testua."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr "Erabili eremu hau eskertza orriaren ordez, formularioaren akzioaren ondoren erakutsiko den helbidea zehazteko. Erabilpen arrunta arrakasta orrialde bat edo script bat exekutatzea da. Utzi hutsik behar ez baduzu. Bestela CMFFormController erako akzio gisa idatzi behar duzu. Adibidez: \"redirect_to\" edo \"traverse_to\" eta ondoren TALES espresio bat. Esaterako: \"redirect_to: string:thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr "Erabili eremu hau eskertza orriaren ordez, formularioaren akzioaren ondoren erakutsiko den helbidea zehazteko. Erabilpen arrunta arrakasta orrialde bat edo script bat exekutatzea da. Utzi hutsik behar ez baduzu. Bestela CMFFormController erako akzio gisa idatzi behar duzu. Adibidez: \"redirect_to\" edo \"traverse_to\" eta ondoren TALES espresio bat. Esaterako: \"redirect_to: string:thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr "Eremuen balioen aurretik erakutsiko den testua."
 
@@ -485,7 +464,7 @@ msgstr "Eremuen balioen aurretik erakutsiko den testua."
 msgid "help_tvalidator_text"
 msgstr "Formularioa balidatzean exekutatuko den TALES espresioa. Erabili 'value' aldagaia balidaziorako, bertan egongo da-eta eremuaren balioa. Itzuli False balio boolearra balioa zuzena bada; bestela itzuli errore mezua. Adb.: \"python:test(value='arrautzak', False, 'Balioa arrautzak izan behar da')\" idatzi gero, eremuaren balioa \"arrautzak\" izan beharko da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr " "
 
@@ -500,46 +479,46 @@ msgid "help_userfield_validators"
 msgstr "Aukeratu eremu honetan erabiliko diren balidadoreak."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr "Mezuan X-Goiburuko bezala txertatuko diren HTTP goiburukoak aukeratu."
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr "Inportatu"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr "Balidazioaren osteko scripta"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr "Formularioa ezartzeko scripta"
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr "BCC espresioa"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr "CC espresioa"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr "CSRF babesa"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr "Eremu-multzoaren defektuzko etiketa"
 
@@ -549,12 +528,12 @@ msgid "label_downloadformat_text"
 msgstr "Deskargatzeko formatua"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr "Formularioaren epilogoa"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr "Exekuzio baldintza"
 
@@ -564,92 +543,92 @@ msgid "label_field_widget"
 msgstr "Eremuaren widgeta"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr "SSL konexioa derrigortu"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr "Eremu-multzoak fitxa bihurtu"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr "Pertsonalizatutako akzioa"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr "Goiburuko gehigarriak"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC jasotzaileak"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr "Gorputza (sinadura)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr "Gorputza (ondoren gehituko dena)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr "Gorputza (aurretik gehituko dena)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr "Mezuaren txantilioia"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr "Mezuaren formatua"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr "CC jasotzaileak"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr "Jasotzailearen eposta"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr "Jasotzailearen izena"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr "Reply-To goiburukoa nondik atera"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr "Gaia"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr "Mezuaren gaia nondik atera"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr "Mezuaren jasotzailea nondik atera"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr "Goiburukoak txertatu"
 
@@ -659,67 +638,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr "Hutsik daudenak sartu"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr "Etiketa"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr "Hutsik daudenak sartu"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr "Eremu guztiak sartu"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr "Erantzunak erakutsi"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr "Formularioaren metodoa"
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr "Formularioaren prologoa"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr "Jasotzailearen espresioa"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr "Reset botoiaren etiketa"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr "Etiketa aberatsa"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -734,27 +718,27 @@ msgid "label_savefields_text"
 msgstr "Gordetako eremuak"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Scriptaren gorputza"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Scriptaren proxy-rola"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr "Bidaltzailearen espresioa"
 
@@ -764,32 +748,32 @@ msgid "label_server_side_text"
 msgstr "Zerbitzariaren aldeko aldagaia"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr "Eremu guztiak erakutsi"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr "Reset botoia erakutsi"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr "Erantzunak erakutsi"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr "Gaiaren espresioa"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr "Bidalketa botoiaren etiketa"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr "Bidalketa botoiaren etiketa pertsonalizatua"
 
@@ -804,32 +788,32 @@ msgid "label_tenabled_text"
 msgstr "Aktibatzeko espresioa"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr "Eskertzaren laburpena"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr "Eskertzaren epilogoa"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr "Arrakasta akzio pertsonalizatua"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr "Arrakasta akzio pertsonalizatu-mota"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr "Eskertzaren prologoa"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr "Eskertzaren izenburua"
 
@@ -839,7 +823,7 @@ msgid "label_tvalidator_text"
 msgstr "Balidadore pertsonalizatua"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr "Babesa"
 
@@ -849,29 +833,34 @@ msgid "label_usecolumnnames_text"
 msgstr "Eremu izenak sartu"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Goiburukoak"
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr "Fitxategia handiegia da"
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr "CSV: komekin banatutako balioak"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr "Bidalketaren data/ordua"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
 msgstr "TSV: Tabulazioekin banatutako balioak"
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
+msgstr ""

--- a/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: 2014-05-06 16.00+0000\n"
 "Last-Translator: Giorgio Borelli\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,15 +23,15 @@ msgstr "${items} elemento/i salvato/i"
 msgid "Action type"
 msgstr "Tipo di azione"
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr "Modello azioni"
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr "Aggiungi azione"
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr "Indirizzi"
 
@@ -52,28 +52,19 @@ msgstr "Definisci le action del form"
 msgid "Define form fields"
 msgstr "Definisci i campi del form"
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr "EasyForm (disinstalla)"
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr ""
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr "Modifica azione '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr "Modifica l'XML delle azioni"
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr "Modifica l'XML dei campi"
 
@@ -81,15 +72,15 @@ msgstr "Modifica l'XML dei campi"
 msgid "Export"
 msgstr "Esporta"
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr "Modello dei campi"
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr "Form importato."
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr "Intestazioni"
 
@@ -97,28 +88,24 @@ msgstr "Intestazioni"
 msgid "Import"
 msgstr "Importa"
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr "Installa il pacchetto collective.easyform"
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr "Non sono consentiti link."
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Dev'essere una lista di indirizzi email validi, separati da virgola."
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr "Dev'essere selezionato."
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr "Dev'essere deselezionato"
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr ""
@@ -127,15 +114,15 @@ msgstr ""
 msgid "Posting Date/Time"
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr "Reindirizza a"
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr "Annulla"
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr ""
 
@@ -143,7 +130,7 @@ msgstr ""
 msgid "Saved data"
 msgstr "Dati salvati"
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr "Pagina di ringraziamento"
 
@@ -152,24 +139,16 @@ msgstr "Pagina di ringraziamento"
 msgid "This Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
 msgstr ""
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr "Disinstalla il pacchetto collective.easyform"
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
-msgstr "Usato solo per test"
 
 #: collective/easyform/interfaces/fields.py:141
 msgid "Validators"
 msgstr "Validatori"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr "Annulla"
 
@@ -179,12 +158,12 @@ msgid "default_submitLabel"
 msgstr "Invia"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr "Grazie per averci contattato."
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr "Grazie"
 
@@ -194,48 +173,48 @@ msgid "description_server_side_text"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} intestazione"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr "Selezionare per abilitare la protezione Cross-Site Request Forgery (CSRF). Notare che verranno ammesse solo azioni HTTP con metodo Post."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr "Questo campo permette di personalizzare il titolo del fieldset di default."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr "Questo testo verrà mostrato dopo i campi del form."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr ""
 
@@ -244,91 +223,91 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr "Usare questo campo per sovrascrivere l'attributo action del form. Speficicare un URL al quale fare la post. Questo bypasserà la validazione dei dati, la gestione dell'invio andato a buon fine e la pagina di ringraziamento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr "Righe di e-mail-header aggiuntive. Usare solo stringhe conformi RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr "Indirizzi E-mail in copia nascosta (bcc)."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr "Testo usato come footer, staccato dal body principale con una linea tratteggiata."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr "Testo aggiunto sotto alla lista dei campi nel mail-body"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr "Testo aggiunto sopra alla lista dei campi nel mail-body"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr "Questo è uno Zope Page Template usato per creare il mail-body. Non è necessario modificarlo, ma se conosci TAL (il linguaggio di templating di Zope) hai il potere di personalizzare totalmente le e-mail inviate."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr "Definisci il mime-type per il mail-body. Cambia questo settaggio solo se sai esattamente quello che stai facendo. Lascia il campo vuoto per lasciare il comportamento di default."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr "Indirizzi E-mail in copia (cc)."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr "L'indirizzo e-mail del destinatario."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr "Il nome completo del destinatario del form."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr "Scegli un campo del form dal quale vorresti estrarre l'indirizzo del destinatario. Se scegli qualcosa di diverso da \"-\", questo campo sovrascrive l'impostazione \"Indirizzo e-mail del destinatario\" precedente. Presta molta attenzione nell'utilizzare input dall'utente senza controlli."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr ""
 
@@ -338,36 +317,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr "Spuntare per mostrare i titoli dei campi che non sono stati compilati. Lasciare senza spunta per non mostrarli."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr "Spuntare per includere i titoli dei campi che non sono stati compilati. Lasciare senza spunta per non includerli nella mail."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr "Spuntare per includere tutti i campi nella mail inviata (tranne label e file). Se attivi questa opzione, le selezioni del box qui sotto verranno ignorate."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr "Scegli quali campi vuoi includere nella mail inviata."
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr "Questo testo verrà mostrato sopra i campi del form."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr ""
 
@@ -377,7 +356,7 @@ msgstr ""
 msgid "help_registry_items"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -392,55 +371,55 @@ msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr "Spuntare per mostrare tutti i campi del form (tranne label e file). Se attivi questa opzione, le selezioni del box qui sotto verranno ignorate."
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr "Scegli quali campi del form vuoi mostrare nella pagina di successo."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
@@ -455,27 +434,27 @@ msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr "Usato nella pagina di ringraziamento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr "Questo testo verrà mostrato dopo i campi di input selezionati."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr "Questo testo verrà mostrato sopra la lista dei campi selezionati."
 
@@ -484,7 +463,7 @@ msgstr "Questo testo verrà mostrato sopra la lista dei campi selezionati."
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -499,46 +478,46 @@ msgid "help_userfield_validators"
 msgstr "Selezionare i validatori da usare per questo campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr "Scegli dalla lista quali HTTP header vorresti inserire come X- header nel messaggio."
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr "Titolo del fieldset di default"
 
@@ -548,12 +527,12 @@ msgid "label_downloadformat_text"
 msgstr "Formato di download"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr "Epilogo del form"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr "Condizioni di esecuzione"
 
@@ -563,92 +542,92 @@ msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr "Forza connessione SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr "Mostra i fieldset in tab separati"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr "Action personalizata per il form"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr "Header aggiuntivi"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinatari in BCC"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr "Body (firma)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr "Body (aggiungi sotto)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr "Body (aggiungi sopra)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinatari in CC"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr "Indirizzo e-mail del destinatario."
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nome completo destinatario"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr "Estrai il Reply-To da"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr "Oggetto"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr "Estrai l'Oggetto da"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr "Estrai il Destinatario da"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr ""
 
@@ -658,67 +637,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr "Includi elementi vuoti"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr "Includi elementi vuoti"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr "Includi tutti i campi"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr "Mostra il responso"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr "Metodo del form"
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr "Prologo del form"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr "Testo del bottone di Annulla"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -733,27 +717,27 @@ msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr ""
 
@@ -763,32 +747,32 @@ msgid "label_server_side_text"
 msgstr "Variabili server-side"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr "Visualizza tutti i campi"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr "Mostra il bottone Annulla"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr "Mostra il responso"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr "Testo del bottone di invio"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr "Test personalizzato del bottone di invio"
 
@@ -803,32 +787,32 @@ msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr "Testo riassuntivo"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr "Epilogo pagina di ringraziamento"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr "Prologo pagina di ringraziamento"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr "Titolo pagina di ringraziamento"
 
@@ -838,7 +822,7 @@ msgid "label_tvalidator_text"
 msgstr "Validatore personalizzato"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr ""
 
@@ -848,29 +832,34 @@ msgid "label_usecolumnnames_text"
 msgstr "Includi i nomi delle colonne"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr "Valori separati da virgola"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
 msgstr "Valori separati da Tab"
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
+msgstr ""

--- a/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2014-06-06 20:13+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: 2019-11-28 17:09+0100\n"
 "Last-Translator: Érico Andrei <ericof@plone.org>\n"
 "Language-Team: \n"
@@ -22,15 +22,15 @@ msgstr "${items} resposta(s) salvas"
 msgid "Action type"
 msgstr "Tipo de ação"
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr "Modelo de ação"
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr "Adicionar nova ação"
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr "Endereçamento"
 
@@ -51,28 +51,19 @@ msgstr "Definir ações do formulário"
 msgid "Define form fields"
 msgstr "Definir campos do formulário"
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "Formulário"
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr "Formulário (desinstalar)"
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr "Formulário (testes)"
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar ação '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr "Editar o XML do modelo de ação"
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr "Editar o XML do modelo de campos"
 
@@ -80,15 +71,15 @@ msgstr "Editar o XML do modelo de campos"
 msgid "Export"
 msgstr "Exportar"
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr "Modelo de campos"
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr "Formulário importado"
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr "Cabeçalhos"
 
@@ -96,28 +87,24 @@ msgstr "Cabeçalhos"
 msgid "Import"
 msgstr "Importar"
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr "Instala o pacote collective.easyform"
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr "Links não são permitidos."
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Deve ser uma lista de endereços de email válidos (separados por vírgulas)."
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr "Deve estar selecionado."
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr "Deve estar não selecionado."
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr "Substituições"
@@ -126,15 +113,15 @@ msgstr "Substituições"
 msgid "Posting Date/Time"
 msgstr "Data/Hora do envio"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr "Redirecionar para"
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr "Limpar"
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr "Rótulo rico"
 
@@ -142,7 +129,7 @@ msgstr "Rótulo rico"
 msgid "Saved data"
 msgstr "Dados salvos"
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr "Página de agradecimento"
 
@@ -151,24 +138,16 @@ msgstr "Página de agradecimento"
 msgid "This Fields are available for your forms."
 msgstr "Estes campos estão disponíveis para seus formulários"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
 msgstr "Traverse para"
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr "Desinstala o pacote collective.easyform."
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
-msgstr "Utilizado para fins de testes."
 
 #: collective/easyform/interfaces/fields.py:141
 msgid "Validators"
 msgstr "Validadores."
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr "Limpar"
 
@@ -178,12 +157,12 @@ msgid "default_submitLabel"
 msgstr "Enviar"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr "Obrigado pelo envio"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr "Obrigado"
 
@@ -193,48 +172,48 @@ msgid "description_server_side_text"
 msgstr "Marca este campo como um valor a ser enviado na requisição para ser utilizado pelas ações do formulário, mas não ser modificado ou exibido aos usuários."
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "Cabeçalho ${name}"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 msgid "help_AfterValidationOverride_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário não é validado, mas antes de chamar um adaptador de ação ou exibir a página de agradecimento. Dados do formulário estarão em no dicionário request.form. Deixe em branco se não for necessário. O caso de uso mais comum para este campo é chamar um script Python para limpar os dados do formulário ou para direcionar para uma ação alternativa. Qualquer valor retornado é ignorado. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário é exibido. Deixe em branco se não for necessário. O caso de uso mais comum é chamar um script Python para popular valores padrão para campos do formulário. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever valores do campo BCC. Recomendamos fortemente utilizar dados não validados do formulário para este propósito. Deixe em branco se não for necessário. Sua expressão deve retornar uma sequência de strings. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever valores do campo CC. Recomendamos fortemente utilizar dados não validados do formulário para este propósito. Deixe em branco se não for necessário. Sua expressão deve retornar uma sequência de strings. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr "Selecione isto para aplicar proteção contra Cross-Site Request Forgery (CSRF). Apenas ações HTTP Post são suportadas."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr "Este campo permite a modificação do rótulo do fieldset padrão."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr "O texto será exibido após os campos do formulário."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 msgid "help_execcondition_text"
 msgstr "Uma expressão TALES que será avaliada para determinar se esta ação deve ser executada. Deixe em branco se não for necessário e a ação será executada. Sua expressão deve retornar um valor boleano; Retorne True caso queira que a ação seja executada. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
@@ -243,91 +222,91 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr "Selecione esta opção para fazer o formulário sempre redirecionar para uma versão SSL (https://) quando acessado via uma URL não segura (http://). Para que isto funcione é necessário que o servidor web suporte o protocolo HTTPS na porta 443 e repasse as requisições para o Zope."
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr "Utilize este campo para sobrescrever o atributo de ação do formulário. Informe a URL para a qual o formulário será enviado. Isto ignorará as validações, ação de sucesso e a página de agradecimento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr "Cabeçalhos de e-mail adicionais. Apenas use cabeçalhos compatíveis com a RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr "Endereços de e-mail que receberão uma cópia oculta."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr "Texto utilizado como rodapé, delimitado do corpo por uma linha tracejada."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr "Texto que sucede os campos listados no corpo do email."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr "Texto que precede os campos listados no corpo do email."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 msgid "help_formmailer_body_pt"
 msgstr "Este é um Zope Page Template usado para renderizar o corpo do e-mail. Você não precisa modificá-lo, mas caso conheça a Zope Template Attribute Language, você terá total controle sobre a personalização do envio de e-mails."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr "Define o mime-type do corpo do e-mail. Altere este valor apenas se souber o que está fazendo. Deixe em branco para o comportamento padrão."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr "Endereços de e-mail que receberão uma cópia da mensagem."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr "Endereço de e-mail do destinatário."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr "Nome do destinatário do formulário."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o cabeçalho Reply-To. AVISO: Você deve ativar a verificação do endereço de e-mail para este campo."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr "Assunto da mensagem. Isto é usado caso você não tenha um campo para assunto ou se o campo estiver em branco."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o Assunto to e-mail."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 msgid "help_formmailer_to_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o cabeçalho destinatário (To). Se você escolher qualquer opção diferente de \"None\", isto sobreescreverá o email do destinatário informado acima."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr "Esta sobreescrita de campo permite que você insira conteúdo dentro do cabeçalho XHTML. Os usos mais comuns são adicionar CSS personalizado ou código JavaScript. Informe uma expressão TALES retornando uma string. A string será inserida sem nenhuma intepretação. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
@@ -337,36 +316,36 @@ msgid "help_hidden"
 msgstr "Campo oculto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr "Selectione para exibir os títulos de campo para campos que não receberam nenhum valor. Deixe desselecionado para que os campos sem valores fiquem fora da lista."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr "Selectione para exibir os títulos de campo para campos que não receberam nenhum valor. Deixe desselecionado para que os campos sem valores fiquem fora do e-mail"
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr "Selectione para exibir os valores para todos os campos (exceção feita a rótulos e campos arquivo). Caso selecione esta opção, ignoraremos as opções seguintes."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr "Escolha campos que terão seus valores incluídos no e-mail."
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr "Este texto será exibido acima dos campos do formulário."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 msgid "help_recipient_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valor informado como endereço do destinatário de e-mail. Recomendamos fortemente que seja utilizado qualquer valor não validado para este propósito. Deixe em branco caso não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
@@ -376,7 +355,7 @@ msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valo
 msgid "help_registry_items"
 msgstr "Selectione os itens do registro que deseja modificar."
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -391,55 +370,55 @@ msgid "help_savefields_text"
 msgstr "Selecione os campos que você deseja ter nos dados salvos. Caso vazio, todos os campos serão salvos."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Escreva seu script aqui."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Papel que executará este script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr "Selecione esta opção para enviar um arquivo CSV anexado contendo os valores preenchidos no formulário."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr "Selecione esta opção para enviar um arquivo XML anexado contendo os valores preenchidos no formulário."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever o cabeçalho \"From\". Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr "Selecione esta opção para exibir os valores de todos os campos (exceção feita a rótulos e campos do tipo arquivo). Caso escolha esta opção, as opções da caixa de seleção serão ignoradas."
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr "Selecione os campos que devem ter seus valores exibidos na página de sucesso."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valor informado para o cabeçalho de assunto do e-mail. Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr "Esta sobreescrita de campo permite que altere o rótulo do botão de envio. O caso de uso é alterar o rótulo utilizando parâmetros da requisição. Informe uma expressão TALES retornando uma string. A string será inserida sem nenhuma intepretação AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário. "
 
@@ -454,27 +433,27 @@ msgid "help_tenabled_text"
 msgstr "Uma expressão TALES que será avaliada para definir se um campo está disponível. Esta expressão deve retornar True caso o campo deva ser exibido ou False caso ele não deva ser exibido. Deixe em branco se não necessário. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr "Utilizado na página de agradecimento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr "O texto será exibido após os valores dos campos."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr "Use este campo ao invés de uma página de agradecimento para determinar qual a ação final após chamar seu adaptador de ação (Caso você tenha algum). Normalmente este campo é utilizado com um script personalizado. Deixe em branco caso não necessário. Caso contrário, informe uma ação do CMFFormController e seu argumento. Por exemplo, \"Redirect to\" e \"string:thanks-page\" para redirecionar para \"thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr "Use este campo ao invés de uma página de agradecimento para determinar qual a ação final após chamar seu adaptador de ação (Caso você tenha algum). Normalmente este campo é utilizado com um script personalizado. Deixe em branco caso não necessário. Caso contrário, informe uma ação do CMFFormController e seu argumento. Por exemplo, \"Redirect to\" e \"string:thanks-page\" para redirecionar para \"thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr "Este texto será exibido acima dos valores de campos escolhidos."
 
@@ -483,7 +462,7 @@ msgstr "Este texto será exibido acima dos valores de campos escolhidos."
 msgid "help_tvalidator_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário é validado. Valide contra 'value', que conterá a entrada do campo. Retorna False se válido, caso contrário retorna uma mensagem de erro. Exemplo: \"python: test(value=='ovos', False, 'valor deve ser ovos')\" obrigará o valor de \"ovos\" para a entrada. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -498,46 +477,46 @@ msgid "help_userfield_validators"
 msgstr "Selecione os validadores a serem utilizados neste campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr "Escolha qualquer informação dos cabeçalhos HTTP para ser inserido como cabeçalho X- na mensagem."
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr "importar"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr "Script pós-validação"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr "Script para configuração do formulário"
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr "Expressão para BCC"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr "Expressão para CC"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr "Proteção CSRF"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr "Script personalizado"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr "Rótulo personalizado para o fieldset padrão"
 
@@ -547,12 +526,12 @@ msgid "label_downloadformat_text"
 msgstr "Formato de download"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr "Epílogo do formulário"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr "Condição de execução"
 
@@ -562,92 +541,92 @@ msgid "label_field_widget"
 msgstr "Widget do campo"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr "Forçar conexão SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr "Converter fieldsets para abas"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr "Ação de formulário personalizada"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr "Cabeçalhos adicionais"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinatários em cópia oculta (BCC)"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr "Corpo (assinatura)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr "Corpo (acrescentar)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr "Corpo (preceder)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr "Modelo do corpo do email"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr "Formato do email"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinatários em cópia (CC)"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr "E-mail do destinatário"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nome do destinatário"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr "Extrair 'responder para' de"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr "Assunto"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr "Extrair assunto de"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr "Extrair destinatário de"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr "Injeção no cabeçalho"
 
@@ -657,67 +636,72 @@ msgid "label_hidden"
 msgstr "Oculto"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr "Incluir campos vazios"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr "Rótulo"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr "Incluir campos vazios"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr "Incluir todos os campos"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr "Mailer"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr "Exibir respostas"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr "Método do formulário"
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr "Prólogo do formulário"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr "Expressão do destinatário"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr "Rótulo do botão de limpeza"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr "Rótulo rico"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr "Salvar dados"
 
@@ -732,27 +716,27 @@ msgid "label_savefields_text"
 msgstr "Campos salvos"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Corpo do script"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy role"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr "Enviar anexo de dados CSV"
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr "Enviar anexo de dados XML"
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr "Expressão de remetente"
 
@@ -762,32 +746,32 @@ msgid "label_server_side_text"
 msgstr "Variável Server-side"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr "Exibir todos os campos"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr "Exibir botão de limpeza"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr "Exibir respostas"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr "Expressão da submissão"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr "Rótulo do botão de submissão"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr "Rótulo do botão de submissão personalizado"
 
@@ -802,32 +786,32 @@ msgid "label_tenabled_text"
 msgstr "Expressão de ativação"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr "Sumário da página de agradecimento"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr "Epílogo da página de agradecimento"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr "Ação de sucesso personalizada"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr "Tipo de ação de sucesso personalizada"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr "Prólogo da página de agradecimento"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr "Título da página de agradecimento"
 
@@ -837,7 +821,7 @@ msgid "label_tvalidator_text"
 msgstr "Validador personalizado"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr "Proteção contra mudança de página"
 
@@ -847,29 +831,34 @@ msgid "label_usecolumnnames_text"
 msgstr "Incluir nome de colunas"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr "Cabeçalhos HTTP"
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr "Valores separados por vírgula"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr "Data/Hora do envio"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
 msgstr "Valores separados por tabulação"
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
+msgstr ""

--- a/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2019-05-09 07:45+0000\n"
+"POT-Creation-Date: 2021-07-14 18:25+0000\n"
 "PO-Revision-Date: 2015-10-13 11:16+0200\n"
 "Last-Translator: Zoriana Zaiats <sorenabell@quintagroup.com>\n"
 "Language-Team: Ukrainian <support@quintagroup.com>\n"
@@ -25,15 +25,15 @@ msgstr "${items} елементів збережено."
 msgid "Action type"
 msgstr "Тип дії"
 
-#: collective/easyform/interfaces/easyform.py:83
+#: collective/easyform/interfaces/easyform.py:85
 msgid "Actions Model"
 msgstr "Модель дій"
 
-#: collective/easyform/browser/actions.py:245
+#: collective/easyform/browser/actions.py:249
 msgid "Add new action"
 msgstr "Додати нову дію"
 
-#: collective/easyform/interfaces/mailer.py:71
+#: collective/easyform/interfaces/mailer.py:74
 msgid "Addressing"
 msgstr "Адреси"
 
@@ -54,28 +54,19 @@ msgstr ""
 msgid "Define form fields"
 msgstr ""
 
-#: collective/easyform/configure.zcml:29
 #: collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/configure.zcml:37
-msgid "EasyForm (uninstall)"
-msgstr ""
-
-#: collective/easyform/configure.zcml:46
-msgid "EasyForm testing"
-msgstr ""
-
-#: collective/easyform/browser/actions.py:308
+#: collective/easyform/browser/actions.py:312
 msgid "Edit Action '${fieldname}'"
 msgstr "Редагувати дію '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:313
+#: collective/easyform/browser/actions.py:317
 msgid "Edit XML Actions Model"
 msgstr "Редагувати XML модель дій"
 
-#: collective/easyform/browser/fields.py:96
+#: collective/easyform/browser/fields.py:95
 msgid "Edit XML Fields Model"
 msgstr "Редагувати XML модель полів"
 
@@ -83,15 +74,15 @@ msgstr "Редагувати XML модель полів"
 msgid "Export"
 msgstr "Експортувати"
 
-#: collective/easyform/interfaces/easyform.py:80
+#: collective/easyform/interfaces/easyform.py:82
 msgid "Fields Model"
 msgstr "Модель полів"
 
-#: collective/easyform/browser/exportimport.py:61
+#: collective/easyform/browser/exportimport.py:59
 msgid "Form imported."
 msgstr "Форму імпортовано."
 
-#: collective/easyform/interfaces/mailer.py:322
+#: collective/easyform/interfaces/mailer.py:325
 msgid "Headers"
 msgstr "Заголовки"
 
@@ -99,28 +90,24 @@ msgstr "Заголовки"
 msgid "Import"
 msgstr "Імпорт"
 
-#: collective/easyform/configure.zcml:29
-msgid "Installs the collective.easyform package"
-msgstr ""
-
-#: collective/easyform/validators.py:53
+#: collective/easyform/validators.py:60
 msgid "Links are not allowed."
 msgstr "Лінки заборонені."
 
-#: collective/easyform/validators.py:28
+#: collective/easyform/validators.py:35
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Повинен бути список дійсних електронних адрес (розділений комами)."
 
-#: collective/easyform/validators.py:38
+#: collective/easyform/validators.py:45
 msgid "Must be checked."
 msgstr "Має бути вибрано."
 
-#: collective/easyform/validators.py:43
+#: collective/easyform/validators.py:50
 msgid "Must be unchecked."
 msgstr "Не має бути вибрано."
 
-#: collective/easyform/interfaces/actions.py:96
-#: collective/easyform/interfaces/easyform.py:178
+#: collective/easyform/interfaces/actions.py:91
+#: collective/easyform/interfaces/easyform.py:180
 #: collective/easyform/interfaces/fields.py:73
 msgid "Overrides"
 msgstr "Перевизначення"
@@ -129,15 +116,15 @@ msgstr "Перевизначення"
 msgid "Posting Date/Time"
 msgstr "Дата/час заповнення"
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Redirect to"
 msgstr "Перенаправити до"
 
-#: collective/easyform/browser/view.py:209
+#: collective/easyform/browser/view.py:208
 msgid "Reset"
 msgstr "Відновити"
 
-#: collective/easyform/interfaces/fields.py:175
+#: collective/easyform/interfaces/fields.py:167
 msgid "Rich Label"
 msgstr "Розширений напис"
 
@@ -145,7 +132,7 @@ msgstr "Розширений напис"
 msgid "Saved data"
 msgstr "Збережені дані"
 
-#: collective/easyform/interfaces/easyform.py:323
+#: collective/easyform/interfaces/easyform.py:325
 msgid "Thanks Page"
 msgstr "Сторінка подяки"
 
@@ -154,24 +141,16 @@ msgstr "Сторінка подяки"
 msgid "This Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:29
+#: collective/easyform/vocabularies.py:31
 msgid "Traverse to"
 msgstr "Траверсити до"
-
-#: collective/easyform/configure.zcml:37
-msgid "UnInstall the collective.easyform package"
-msgstr ""
-
-#: collective/easyform/configure.zcml:46
-msgid "Used for testing only"
-msgstr ""
 
 #: collective/easyform/interfaces/fields.py:141
 msgid "Validators"
 msgstr "Валідатори"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:30
+#: collective/easyform/interfaces/easyform.py:31
 msgid "default_resetLabel"
 msgstr ""
 
@@ -181,12 +160,12 @@ msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:40
+#: collective/easyform/interfaces/easyform.py:43
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:35
+#: collective/easyform/interfaces/easyform.py:37
 msgid "default_thankstitle"
 msgstr ""
 
@@ -196,49 +175,49 @@ msgid "description_server_side_text"
 msgstr "Позначити це поле як значення, що буде вставлене у форму запиту, що використовуватиметься адаптерами дії, і не буде модифікуватись чи надаватись клієнту."
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:353
+#: collective/easyform/interfaces/mailer.py:356
 #: collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} Заголовок"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:271
+#: collective/easyform/interfaces/easyform.py:273
 #, fuzzy
 msgid "help_AfterValidationOverride_text"
 msgstr "TALES вираз, який буде викликано після успішної перевірки форми, але до виклику адаптера дії (якщо такий є), чи відображення сторінки подяки. Вміст форми буде у словнику request.form. Заповнювати поле не обов'язково. Найпоширеніше використання цього поля - для виклику python скрипта, що видаляє дані, введені в форму, або для додання альтернативної дії. Будь-яке значення, що поверне цей вираз, буде проігнороване. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:251
+#: collective/easyform/interfaces/easyform.py:253
 msgid "help_OnDisplayOverride_text"
 msgstr "TALES вираз, який буде викликано при відображенні форми. Заповнювати поле не обов'язково. Найпоширеніше використання цього поля - це виклик python скрипта, що встановлює значення за замовчуванням для багатьох полів у request.form. Будь-яке значення, що поверне цей вираз, буде проігнороване. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:453
+#: collective/easyform/interfaces/mailer.py:456
 msgid "help_bcc_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в список прихованих копій (BСС). Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як послідовність рядків. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:433
+#: collective/easyform/interfaces/mailer.py:436
 msgid "help_cc_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в список копій (СС). Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як послідовність рядків. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:136
+#: collective/easyform/interfaces/easyform.py:138
 msgid "help_csrf"
 msgstr "Позначте, щоб застосувати захист від підробки міжсайтових запитів (Cross-Site Request Forgery protection). Пам'ятайте, що лише дії HTTP Post будуть дозволені."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:121
+#: collective/easyform/interfaces/easyform.py:123
 msgid "help_default_fieldset_label_text"
 msgstr "Це поле дозволяє змінити заголовок набору полів за замовчуванням."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:170
+#: collective/easyform/interfaces/easyform.py:172
 msgid "help_epilogue_text"
 msgstr "Текст буде розміщено після полів форми."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:101
+#: collective/easyform/interfaces/actions.py:96
 #, fuzzy
 msgid "help_execcondition_text"
 msgstr "TALES вираз, що буде обчислюватися, щоб визначити - виконувати, чи не виконувати цю дію. Заповнювати поле не обов'язково. Якщо ви залишите поле пустим, дія буде виконуватись. Ваш вираз повинен обчислюватись як логічна змінна: повертає True, якщо ви хочете, щоб дія виконувалась. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
@@ -248,93 +227,93 @@ msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:148
+#: collective/easyform/interfaces/easyform.py:150
 msgid "help_force_ssl"
 msgstr "Позначте, щоб форма переходила на свою безпечну версію з SSL протоколом (https://), якщо використовується звичайний URL (http://) без SSL протоколу. Для правильного функціонування, потрібен веб сервер, налаштований для обробки протоколу HTTPS на порті 443 і його перенаправлення на Zope."
 
-#: collective/easyform/interfaces/easyform.py:112
+#: collective/easyform/interfaces/easyform.py:114
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:237
+#: collective/easyform/interfaces/easyform.py:239
 msgid "help_formactionoverride_text"
 msgstr "Використовуйте це поле, щоб перевизначити властивість дії форми. Вкажіть URL-адресу, куди буде розміщена форма. Це обійде перевірку форми, адаптер успішної дії та сторінку подяки."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:345
+#: collective/easyform/interfaces/mailer.py:348
 msgid "help_formmailer_additional_headers"
 msgstr "Додаткові рядки заголовка електронного листа. Використовуйте лише RFC822-сумісні заголовки."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:107
+#: collective/easyform/interfaces/mailer.py:110
 msgid "help_formmailer_bcc_recipients"
 msgstr "Адреси електронних пошт, які отримають приховані копії."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:209
+#: collective/easyform/interfaces/mailer.py:212
 msgid "help_formmailer_body_footer"
 msgstr "Текст, що буде відображатись у нижньому колонтитулі, відділений від основного тексту пунктирною лінією."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:194
+#: collective/easyform/interfaces/mailer.py:197
 msgid "help_formmailer_body_post"
 msgstr "Текст, що буде доданий до полів, перерахованих в основній частині електронного листа."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:179
+#: collective/easyform/interfaces/mailer.py:182
 msgid "help_formmailer_body_pre"
 msgstr "Текст, що буде доданий перед полями, перерахованими в основній частині електронного листа."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:297
+#: collective/easyform/interfaces/mailer.py:300
 #, fuzzy
 msgid "help_formmailer_body_pt"
 msgstr "Це шаблон сторінки у Zope, що використовується для обробки електронного листа. Немає потреби його змінювати, хоча, якщо ви знайомі з  TAL (Template Attribute Language для Zope), то у вас є всі можливості для налаштування вихідних електронних повідомлень."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:312
+#: collective/easyform/interfaces/mailer.py:315
 msgid "help_formmailer_body_type"
 msgstr "Задайте mime тип основної частини електронного листа. Змінюйте налаштування лише тоді, коли ви дійсно впевнені в правильності своїх дій. Залишіть поле пустим для налаштувань за замовчуванням."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:94
+#: collective/easyform/interfaces/mailer.py:97
 msgid "help_formmailer_cc_recipients"
 msgstr "Адреси електронної пошти, які отримають копію листа."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:63
+#: collective/easyform/interfaces/mailer.py:66
 msgid "help_formmailer_recipient_email"
 msgstr "Адреса електронної пошти отримувача."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:48
+#: collective/easyform/interfaces/mailer.py:51
 msgid "help_formmailer_recipient_fullname"
 msgstr "Повне ім'я отримувача електронного листа з формою."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:120
+#: collective/easyform/interfaces/mailer.py:123
 msgid "help_formmailer_replyto_extract"
 msgstr "Виберіть поле форми, з якого будуть братися дані для заголовка листа-відповіді. ПРИМІТКА: Увімкніть перевірку адрес електронних пошт для цього поля."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:149
+#: collective/easyform/interfaces/mailer.py:152
 msgid "help_formmailer_subject"
 msgstr "Тема повідомлення. Вона буде використана, якщо поле теми не вказане, або це поле пусте."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:165
+#: collective/easyform/interfaces/mailer.py:168
 msgid "help_formmailer_subject_extract"
 msgstr "Виберіть поле форми, з якого будуть братися дані для теми листа."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:78
+#: collective/easyform/interfaces/mailer.py:81
 #, fuzzy
 msgid "help_formmailer_to_extract"
 msgstr "Виберіть поле форми, з якого буде взята інформація для заголовка \"Кому\". Якщо ви виберете будь-що інше крім \"Жоден\", це перекриє налаштування \"Адреса електронної пошти отримувача\" вище. Будьте обережними з введенням цієї інформації."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:291
+#: collective/easyform/interfaces/easyform.py:293
 msgid "help_headerInjection_text"
 msgstr "Це поле перевизначення дозволяє вставити вміст в xhtml-заголовок. Переважно поле використовується для додавання користувацького CSS або JavaScript коду. Вкажіть TALES вираз, що повертає рядок. Рядок буде вставлено ​​без перетворень. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
@@ -344,36 +323,36 @@ msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:372
+#: collective/easyform/interfaces/easyform.py:374
 msgid "help_includeEmpties_text"
 msgstr "Позначте для відображення назв незаповнених полів. Не позначайте і порожні поля не відображатимуться у списку."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:253
+#: collective/easyform/interfaces/mailer.py:256
 msgid "help_mailEmpties_text"
 msgstr "Позначте для включення назв незаповнених полів. Не позначайте і порожні поля не відображатимуться в електронному листі."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:225
+#: collective/easyform/interfaces/mailer.py:228
 msgid "help_mailallfields_text"
 msgstr "Позначте, щоб вибрати вхідні дані для всіх полів (крім написів і файлових типів вмісту). При виборі цього пункту, всі нижче перечислені пункти будуть проігноровані."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:240
+#: collective/easyform/interfaces/mailer.py:243
 msgid "help_mailfields_text"
 msgstr "Виберіть поля, дані з яких будуть включені в електронний лист."
 
-#: collective/easyform/interfaces/easyform.py:105
+#: collective/easyform/interfaces/easyform.py:107
 msgid "help_method"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:162
+#: collective/easyform/interfaces/easyform.py:164
 msgid "help_prologue_text"
 msgstr "Цей текст буде відображатись над полями форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:412
+#: collective/easyform/interfaces/mailer.py:415
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в поле адреси електронної пошти отримувача. Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
@@ -384,7 +363,7 @@ msgstr "TALES вираз, що буде обчислюватися для пер
 msgid "help_registry_items"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:99
+#: collective/easyform/interfaces/easyform.py:101
 msgid "help_reset_button"
 msgstr ""
 
@@ -399,55 +378,55 @@ msgid "help_savefields_text"
 msgstr "Виберіть поля, дані з яких будуть збережені. Якщо жодне поле не вибране, то зберігатимуться всі вхідні дані."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:33
+#: collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Додайте ваш скрипт сюди."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:22
+#: collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Роль від якої запускатиметься скрипт."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:267
+#: collective/easyform/interfaces/mailer.py:270
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:281
+#: collective/easyform/interfaces/mailer.py:284
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:394
+#: collective/easyform/interfaces/mailer.py:397
 msgid "help_sender_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення заголовка \"Від кого\". Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:348
+#: collective/easyform/interfaces/easyform.py:350
 msgid "help_showallfields_text"
 msgstr "Позначте, щоб відображати вхідні дані для всіх полів (крім заголовків/написів і файлових типів вмісту). При виборі цього пункту, всі нижче перечислені пункти будуть проігноровані."
 
-#: collective/easyform/interfaces/easyform.py:93
+#: collective/easyform/interfaces/easyform.py:95
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:361
+#: collective/easyform/interfaces/easyform.py:363
 msgid "help_showfields_text"
 msgstr "Виберіть поля, дані з яких будуть відображатись на сторінці, що повідомлятиме про успішне заповнення форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:375
+#: collective/easyform/interfaces/mailer.py:378
 msgid "help_subject_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в поле заголовка електронного листа. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: collective/easyform/interfaces/easyform.py:87
+#: collective/easyform/interfaces/easyform.py:89
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:309
+#: collective/easyform/interfaces/easyform.py:311
 msgid "help_submitlabeloverride_text"
 msgstr "Це поле перевизначення дозволяє змінити напис кнопки Надіслати. Переважно поле використовується для встановлення напису з параметрами запиту. Вкажіть TALES вираз, що повертає рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
@@ -463,27 +442,27 @@ msgid "help_tenabled_text"
 msgstr "TALES вираз, що буде обчислюватися коли відображатиметься форма, щоб визначити, чи включене поле. Ваш вираз повинен обчислюватись як True, якщо поле повинне бути включене в форму, False - якщо його треба пропустити. Заповнювати поле не обов'язково. Якщо залишити поле для виразу пустим, поле буде включене. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:341
+#: collective/easyform/interfaces/easyform.py:343
 msgid "help_thanksdescription"
 msgstr "Використовується на сторінці подяки."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:392
+#: collective/easyform/interfaces/easyform.py:394
 msgid "help_thanksepilogue_text"
 msgstr "Текст буде відображатись після інформації, вказаної в полі."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:216
+#: collective/easyform/interfaces/easyform.py:218
 msgid "help_thankspageoverride_text"
 msgstr "Використовуйте це поле замість призначення сторінки подяки, щоб визначити фінальну дію після виклику адаптера дії (якщо такий є). Переважно використовується для користувацького шаблону чи скрипту. Заповнювати поле не обов'язково. Вкажіть тип дії CMFFormController та аргумент, і доповніть типом дії для виконання (наприклад, \"redirect_to\" або \"traverse_to\") та TALES виразом. Наприклад, \"Redirect to\" і \"string:thanks-page\" переадресує на \"thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:195
+#: collective/easyform/interfaces/easyform.py:197
 msgid "help_thankspageoverrideaction_text"
 msgstr "Використовуйте це поле замість призначення сторінки подяки, щоб визначити фінальну дію після виклику адаптера дії (якщо такий є). Переважно використовується для користувацького шаблону чи скрипту. Заповнювати поле не обов'язково. Вкажіть тип дії CMFFormController та аргумент, і доповніть типом дії для виконання (наприклад, \"redirect_to\" або \"traverse_to\") та TALES виразом. Наприклад, \"Redirect to\" і \"string:thanks-page\" переадресує на \"thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:384
+#: collective/easyform/interfaces/easyform.py:386
 msgid "help_thanksprologue_text"
 msgstr "Текст буде відображатись над вибраними полями."
 
@@ -492,7 +471,7 @@ msgstr "Текст буде відображатись над вибраними
 msgid "help_tvalidator_text"
 msgstr "TALES вираз, що буде обчислюватися після перевірки форми. Перевіряється ’значення’, яке буде містити дані введені в поле. Вернути False, якщо дані вірні, якщо не вірні, то вернути повідомлення про помилку. Наприклад, \"python: test(value=='eggs', False, 'input must be eggs')\" вимагатиме вводити \"eggs\". ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: collective/easyform/interfaces/easyform.py:130
+#: collective/easyform/interfaces/easyform.py:132
 msgid "help_unload_protection"
 msgstr ""
 
@@ -507,46 +486,46 @@ msgid "help_userfield_validators"
 msgstr "Виберіть валідатори для цього поля."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:329
+#: collective/easyform/interfaces/mailer.py:332
 msgid "help_xinfo_headers_text"
 msgstr "Виберіть будь-яку частину HTTP-заголовків, які будуть вставлені як Х-заголовки в повідомлення."
 
-#: collective/easyform/browser/exportimport.py:51
+#: collective/easyform/browser/exportimport.py:49
 msgid "import"
 msgstr "Імпорт"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:268
+#: collective/easyform/interfaces/easyform.py:270
 msgid "label_AfterValidationOverride_text"
 msgstr "Скрипт після перевірки"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:250
+#: collective/easyform/interfaces/easyform.py:252
 msgid "label_OnDisplayOverride_text"
 msgstr "Скрипт для налаштування форми"
 
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:452
+#: collective/easyform/interfaces/mailer.py:455
 msgid "label_bcc_override_text"
 msgstr "Вираз для прихованої копії"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:432
+#: collective/easyform/interfaces/mailer.py:435
 msgid "label_cc_override_text"
 msgstr "Вираз для копії"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:135
+#: collective/easyform/interfaces/easyform.py:137
 msgid "label_csrf"
 msgstr "Захист від CSRF атак"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:791
+#: collective/easyform/actions.py:836
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:117
+#: collective/easyform/interfaces/easyform.py:119
 msgid "label_default_fieldset_label_text"
 msgstr "Користувацький заголовок стандартного набору полів"
 
@@ -556,12 +535,12 @@ msgid "label_downloadformat_text"
 msgstr "Формат завантаження"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:169
+#: collective/easyform/interfaces/easyform.py:171
 msgid "label_epilogue_text"
 msgstr "Епілог форми"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:100
+#: collective/easyform/interfaces/actions.py:95
 msgid "label_execcondition_text"
 msgstr "Умова для виконання"
 
@@ -571,92 +550,92 @@ msgid "label_field_widget"
 msgstr "Віджет поля"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:147
+#: collective/easyform/interfaces/easyform.py:149
 msgid "label_force_ssl"
 msgstr "Форсувати SSL з’єднання"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:111
+#: collective/easyform/interfaces/easyform.py:113
 msgid "label_form_tabbing"
 msgstr "Перетворити набори полів на таби"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:236
+#: collective/easyform/interfaces/easyform.py:238
 msgid "label_formactionoverride_text"
 msgstr "Користувацька дія для форми"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:344
+#: collective/easyform/interfaces/mailer.py:347
 msgid "label_formmailer_additional_headers"
 msgstr "Додаткові заголовки"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:106
+#: collective/easyform/interfaces/mailer.py:109
 msgid "label_formmailer_bcc_recipients"
 msgstr "Отримувачі прихованої копії"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:208
+#: collective/easyform/interfaces/mailer.py:211
 msgid "label_formmailer_body_footer"
 msgstr "Основна частина (підпис)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:193
+#: collective/easyform/interfaces/mailer.py:196
 msgid "label_formmailer_body_post"
 msgstr "Основна частина (прикріплено після)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:178
+#: collective/easyform/interfaces/mailer.py:181
 msgid "label_formmailer_body_pre"
 msgstr "Основна частина (прикріплено до)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:296
+#: collective/easyform/interfaces/mailer.py:299
 msgid "label_formmailer_body_pt"
 msgstr "Шаблон основної частини листа"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:311
+#: collective/easyform/interfaces/mailer.py:314
 msgid "label_formmailer_body_type"
 msgstr "Формат електронного листа"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:93
+#: collective/easyform/interfaces/mailer.py:96
 msgid "label_formmailer_cc_recipients"
 msgstr "Отримувачі копії"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:60
+#: collective/easyform/interfaces/mailer.py:63
 msgid "label_formmailer_recipient_email"
 msgstr "Адреса електронної пошти отримувача"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:45
+#: collective/easyform/interfaces/mailer.py:48
 msgid "label_formmailer_recipient_fullname"
 msgstr "Повне ім'я отримувача"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:119
+#: collective/easyform/interfaces/mailer.py:122
 msgid "label_formmailer_replyto_extract"
 msgstr "Взяти Відповісти-Кому з"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:148
+#: collective/easyform/interfaces/mailer.py:151
 msgid "label_formmailer_subject"
 msgstr "Тема"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:164
+#: collective/easyform/interfaces/mailer.py:167
 msgid "label_formmailer_subject_extract"
 msgstr "Взяти Тему з"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:77
+#: collective/easyform/interfaces/mailer.py:80
 msgid "label_formmailer_to_extract"
 msgstr "Взяти Отримувача з"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:290
+#: collective/easyform/interfaces/easyform.py:292
 msgid "label_headerInjection_text"
 msgstr "Вставка заголовку"
 
@@ -666,67 +645,72 @@ msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:371
+#: collective/easyform/interfaces/easyform.py:373
 msgid "label_includeEmpties_text"
 msgstr "Включати пусті поля"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:105
+#: collective/easyform/fields.py:194
 msgid "label_label_field"
 msgstr "Напис"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:252
+#: collective/easyform/interfaces/mailer.py:255
 msgid "label_mailEmpties_text"
 msgstr "Включати пусті поля"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:224
+#: collective/easyform/interfaces/mailer.py:227
 msgid "label_mailallfields_text"
 msgstr "Включати всі поля"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:786
+#: collective/easyform/actions.py:831
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:239
+#: collective/easyform/interfaces/mailer.py:242
 msgid "label_mailfields_text"
 msgstr "Показати відповіді"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:104
+#: collective/easyform/interfaces/easyform.py:106
 msgid "label_method"
 msgstr "Метод форми"
 
+#. Default: "NorobotCaptcha"
+#: collective/easyform/fields.py:222
+msgid "label_norobot_field"
+msgstr ""
+
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:161
+#: collective/easyform/interfaces/easyform.py:163
 msgid "label_prologue_text"
 msgstr "Пролог форми"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:122
+#: collective/easyform/fields.py:210
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:411
+#: collective/easyform/interfaces/mailer.py:414
 msgid "label_recipient_override_text"
 msgstr "Вираз для Отримувача"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:98
+#: collective/easyform/interfaces/easyform.py:100
 msgid "label_reset_button"
 msgstr "Напис кнопки скидання"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:107
+#: collective/easyform/fields.py:196
 msgid "label_richlabel_field"
 msgstr "Розширений напис"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:796
+#: collective/easyform/actions.py:841
 msgid "label_savedata_action"
 msgstr ""
 
@@ -741,27 +725,27 @@ msgid "label_savefields_text"
 msgstr "Збережені поля"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:32
+#: collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Текст скрипта"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:21
+#: collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Проксі роль"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:266
+#: collective/easyform/interfaces/mailer.py:269
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:280
+#: collective/easyform/interfaces/mailer.py:283
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:393
+#: collective/easyform/interfaces/mailer.py:396
 msgid "label_sender_override_text"
 msgstr "Вираз для Відправника"
 
@@ -771,32 +755,32 @@ msgid "label_server_side_text"
 msgstr "Змінна для серверної сторони"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:347
+#: collective/easyform/interfaces/easyform.py:349
 msgid "label_showallfields_text"
 msgstr "Показувати всі поля"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:92
+#: collective/easyform/interfaces/easyform.py:94
 msgid "label_showcancel_text"
 msgstr "Показувати кнопку скидання"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:360
+#: collective/easyform/interfaces/easyform.py:362
 msgid "label_showfields_text"
 msgstr "Показувати відповіді"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:374
+#: collective/easyform/interfaces/mailer.py:377
 msgid "label_subject_override_text"
 msgstr "Вираз для Теми"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:86
+#: collective/easyform/interfaces/easyform.py:88
 msgid "label_submitlabel_text"
 msgstr "Напис кнопки Надіслати"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:306
+#: collective/easyform/interfaces/easyform.py:308
 msgid "label_submitlabeloverride_text"
 msgstr "Користувацький напис кнопки Надіслати"
 
@@ -811,32 +795,32 @@ msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:340
+#: collective/easyform/interfaces/easyform.py:342
 msgid "label_thanksdescription"
 msgstr "Короткий опис сторінки подяки"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:391
+#: collective/easyform/interfaces/easyform.py:393
 msgid "label_thanksepilogue_text"
 msgstr "Епілог сторінки подяки"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:215
+#: collective/easyform/interfaces/easyform.py:217
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:191
+#: collective/easyform/interfaces/easyform.py:193
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:383
+#: collective/easyform/interfaces/easyform.py:385
 msgid "label_thanksprologue_text"
 msgstr "Пролог сторінки подяки"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:335
+#: collective/easyform/interfaces/easyform.py:337
 msgid "label_thankstitle"
 msgstr "Назва сторінки подяки"
 
@@ -846,7 +830,7 @@ msgid "label_tvalidator_text"
 msgstr "Додатковий валідатор"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:129
+#: collective/easyform/interfaces/easyform.py:131
 msgid "label_unload_protection"
 msgstr ""
 
@@ -856,29 +840,34 @@ msgid "label_usecolumnnames_text"
 msgstr "Включати назви колонок"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:328
+#: collective/easyform/interfaces/mailer.py:331
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Заголовки"
 
-#: collective/easyform/browser/view.py:390
+#: collective/easyform/browser/view.py:397
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:381
+#: collective/easyform/browser/view.py:388
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: collective/easyform/vocabularies.py:80
 msgid "vocabulary_csv_text"
 msgstr "Значення, розділені комою"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:66
+#: collective/easyform/vocabularies.py:68
 msgid "vocabulary_postingdt_text"
 msgstr "Дата і час відправлення"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:77
+#: collective/easyform/vocabularies.py:79
 msgid "vocabulary_tsv_text"
 msgstr "Значення, розділені табуляцією"
+
+#. Default: "XLSX"
+#: collective/easyform/vocabularies.py:85
+msgid "vocabulary_xlsx_text"
+msgstr ""

--- a/src/collective/easyform/vocabularies.py
+++ b/src/collective/easyform/vocabularies.py
@@ -2,6 +2,7 @@
 from collective.easyform import easyformMessageFactory as _  # NOQA
 from collective.easyform.api import get_context
 from collective.easyform.api import get_schema
+from collective.easyform.config import HAS_XLSX_SUPPORT
 from plone.schemaeditor.interfaces import IFieldFactory
 from zope.component import getUtilitiesFor
 from zope.globalrequest import getRequest
@@ -11,6 +12,7 @@ from zope.interface import provider
 from zope.schema import getFieldsInOrder
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleVocabulary
+
 
 import operator
 
@@ -77,6 +79,11 @@ def FormatDLVocabularyFactory(context):
         (_(u"vocabulary_tsv_text", default=u"Tab-Separated Values"), u"tsv"),
         (_(u"vocabulary_csv_text", default=u"Comma-Separated Values"), u"csv"),
     ]
+
+    if HAS_XLSX_SUPPORT:
+        items.append(
+            (_(u"vocabulary_xlsx_text", default=u"XLSX"), u"xlsx"),
+        )
     return _make_vocabulary(items)
 
 

--- a/tests-5.0.x.cfg
+++ b/tests-5.0.x.cfg
@@ -14,7 +14,7 @@ parts=
     createcoverage
 
 package-name = collective.easyform
-package-extras = [test]
+package-extras = [test,downloadxlsx]
 test-eggs =
 
 [versions]
@@ -27,3 +27,4 @@ plone.app.robotframework = 1.5.0
 plone.formwidget.recaptcha = 2.1.0
 pycodestyle = 2.5.0
 flake8 = 3.7.9
+openpyxl = 2.6.3

--- a/tests-5.1.x.cfg
+++ b/tests-5.1.x.cfg
@@ -11,7 +11,7 @@ parts +=
     createcoverage
 
 package-name = collective.easyform
-package-extras = [test,ploneformgen]
+package-extras = [test,ploneformgen,downloadxlsx]
 test-eggs =
 
 [versions]
@@ -22,3 +22,4 @@ coverage = >=3.7
 plone.app.mosaic =
 plone.app.robotframework = 1.5.0
 plone.formwidget.recaptcha = 2.1.0
+openpyxl = 2.6.3

--- a/tests-5.2.x.cfg
+++ b/tests-5.2.x.cfg
@@ -11,7 +11,7 @@ parts +=
     createcoverage
 
 package-name = collective.easyform
-package-extras = [test]
+package-extras = [test,downloadxlsx]
 test-eggs =
 
 # Python3 compatibility for plone.formwidget.z3cform is not released
@@ -28,6 +28,7 @@ zc.buildout =
 coverage = >=3.7
 plone.app.mosaic =
 plone.app.robotframework = 1.5.0
+openpyxl = 2.6.3
 
 [sources]
 plone.formwidget.recaptcha = git ${remotes:plone}/plone.formwidget.recaptcha.git pushurl=${remotes:plone_push}/plone.formwidget.recaptcha.git


### PR DESCRIPTION
- Based on openpyxl
- Available as an extra (by default it's not available, nor is openpyxl required)
- I did a tiny refactoring to reuse gathering the header and row data

All data saver related tests are passing on my machine (including the newly added xlsx download test):

```
$ ./bin/test -t testSaver
...
truncated
...
Running collective.easyform.tests.base.collective.easyform:Integration tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.zope.Startup in 0.243 seconds.
  Set up plone.app.testing.layers.PloneFixture in 5.177 seconds.
  Set up plone.app.event.testing.PAEventLayer in 0.171 seconds.
  Set up plone.app.contenttypes.testing.PloneAppContenttypes in 0.093 seconds.
  Set up collective.easyform.tests.base.Fixture /Users/maethu/dotfiles/.buildout/eggs/zope.configuration-4.4.0-py2.7.egg/zope/configuration/fields.py:533: UserWarning: You did not specify an i18n translation domain for the 'title' field in /Users/maethu/4teamwork/ai.web/src/collective.easyform/src/collective/easyform/permissions.zcml
  "'%s' field in %s" % (self.getName(), context.info.file)
/Users/maethu/dotfiles/.buildout/eggs/zope.configuration-4.4.0-py2.7.egg/zope/configuration/fields.py:533: UserWarning: You did not specify an i18n translation domain for the 'title' field in /Users/maethu/4teamwork/ai.web/src/collective.easyform/src/collective/easyform/configure.zcml
  "'%s' field in %s" % (self.getName(), context.info.file)
/Users/maethu/dotfiles/.buildout/eggs/zope.configuration-4.4.0-py2.7.egg/zope/configuration/fields.py:533: UserWarning: You did not specify an i18n translation domain for the 'description' field in /Users/maethu/4teamwork/ai.web/src/collective.easyform/src/collective/easyform/configure.zcml
  "'%s' field in %s" % (self.getName(), context.info.file)
in 0.260 seconds.
  Set up collective.easyform.tests.base.collective.easyform:Integration in 0.000 seconds.
  Running:

  Ran 21 tests with 0 failures, 0 errors, 0 skipped in 1.348 seconds.
Tearing down left over layers:
  Tear down collective.easyform.tests.base.collective.easyform:Integration in 0.000 seconds.
  Tear down collective.easyform.tests.base.Fixture in 0.006 seconds.
  Tear down plone.app.contenttypes.testing.PloneAppContenttypes in 0.027 seconds.
  Tear down plone.app.event.testing.PAEventLayer in 0.006 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.053 seconds.
  Tear down plone.testing.zope.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.000 seconds.
```

Example output as XLSX:
[example_file.xlsx](https://github.com/collective/collective.easyform/files/6818240/example_file.xlsx)
