### PR TITLE
Saving certain data types caused issues writing them into a xlsx cell.

### DIFF
--- a/src/collective/easyform/tests/fixtures/fieldset_multiple_choice.xml
+++ b/src/collective/easyform/tests/fixtures/fieldset_multiple_choice.xml
@@ -1,0 +1,44 @@
+<model xmlns="http://namespaces.plone.org/supermodel/schema"
+       xmlns:easyform="http://namespaces.plone.org/supermodel/easyform"
+       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+       i18n:domain="collective.easyform"
+>
+  <schema>
+    <field easyform:TDefault="python:member and member.getProperty('email', '') or ''"
+           easyform:serverSide="False"
+           easyform:validators="isValidEmail"
+           name="replyto"
+           type="zope.schema.TextLine"
+    >
+      <description />
+      <title>Your E-Mail Address</title>
+    </field>
+    <field name="topic"
+           type="zope.schema.TextLine"
+    >
+      <description />
+      <title>Subject</title>
+    </field>
+    <field name="comments"
+           type="zope.schema.Text"
+    >
+      <description />
+      <title>Comments</title>
+    </field>
+    <field name="multiplechoice" type="zope.schema.Set">
+      <description />
+      <required>False</required>
+      <title>Multiplechoice</title>
+      <value_type type="zope.schema.Choice">
+        <values>
+          <element>Red</element>
+          <element>Blue</element>
+          <element>Gr&#252;n</element>
+          <element>Black </element>
+          <element>White</element>
+        </values>
+      </value_type>
+    </field>
+
+  </schema>
+</model>

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -8,6 +8,8 @@ from collective.easyform.api import get_schema
 from collective.easyform.interfaces import ISaveData
 from collective.easyform.tests import base
 from openpyxl import load_workbook
+from os.path import dirname
+from os.path import join
 from plone import api
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
@@ -282,6 +284,9 @@ class SaveDataTestCase(base.EasyFormTestCase):
 
     def testSaverDownloadXLSX(self):
         """test save data"""
+
+        with open(join(dirname(__file__), "fixtures", "fieldset_multiple_choice.xml")) as f:
+            self.ff1.fields_model = f.read()
 
         self.createSaver()
 

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -300,6 +300,7 @@ class SaveDataTestCase(base.EasyFormTestCase):
             topic="test subject",
             replyto="test@test.org",
             comments="test comments",
+            multiplechoice=[u"Red", u"Blue"]
         )
         saver.onSuccess(request.form, request)
 
@@ -321,10 +322,11 @@ class SaveDataTestCase(base.EasyFormTestCase):
         ws = wb.active
         rows = list(ws.rows)
 
-        self.assertEqual(len(rows), 1)
-        self.assertEqual(rows[0][0].value, "test@test.org")
-        self.assertEqual(rows[0][1].value, "test subject")
-        self.assertEqual(rows[0][2].value, "test comments")
+        self.assertEqual(len(rows), 2)  # Row 1 is the header row
+        self.assertEqual(rows[1][0].value, "test@test.org")
+        self.assertEqual(rows[1][1].value, "test subject")
+        self.assertEqual(rows[1][2].value, "test comments")
+        self.assertEqual(rows[1][3].value, '["Red", "Blue"]')
 
     def testSaverDownloadWithTitles(self):
         """test save data"""


### PR DESCRIPTION
This PR re-uses the `serialize` method introduced in the `mailer` action for the xlsx data saver (resp. downloader).
I notised that especially list types are not working. 

Tests of `testSaver` and `testMailer` are passing running with python 2.7.18 and python 3.8.6

I did not add a new changlog entry since this fix belongs to the not yet released feature "Download XLSX version of saved data"