### PR TITLE
Update rolemap.xml

### DIFF
--- a/src/collective/easyform/profiles/default/rolemap.xml
+++ b/src/collective/easyform/profiles/default/rolemap.xml
@@ -32,6 +32,7 @@
                 name="collective.easyform: Edit TALES Fields"
     >
       <role name="Manager" />
+      <role name="Site Administrator" />
     </permission>
     <permission acquire="True"
                 name="collective.easyform: Edit Python Fields"


### PR DESCRIPTION
tales fields are useful to rewrite the sender. Until there's no such option in Default, better to give this power to Site Administrators. I know this can be risky, so this is just a first try to solve the issue