### PR TITLE
Few UX improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,12 @@ Bug fixes;
 - Fix persistence issue with SaveData storage.
   [mathias.leimgruber] (#259)
 
+Enhancements:
+
+- Standarize how the "Form Fields" and "Form Actions" behave. Have a single
+  "Save" button that will redirect back to the form once changes are applied
+  [frapell]
+
 
 4.0.0 (2022-04-07)
 ------------------

--- a/src/collective/easyform/browser/actions.py
+++ b/src/collective/easyform/browser/actions.py
@@ -268,7 +268,7 @@ class EasyFormActionsListing(SchemaListing):
 
         # update widgets to take the new defaults into account
         self.updateWidgets()
-        self.request.response.redirect(self.context.absolute_url())
+        self.request.response.redirect(aq_parent(self.context).absolute_url())
 
     def handleModelEdit(self, action):
         self.request.response.redirect("@@modeleditor")

--- a/src/collective/easyform/browser/fields.py
+++ b/src/collective/easyform/browser/fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from AccessControl import Unauthorized
+from Acquisition import aq_parent
 from collective.easyform import easyformMessageFactory as _
 from collective.easyform.api import get_schema
 from collective.easyform.interfaces import IEasyFormFieldContext
@@ -90,8 +91,25 @@ class FieldsSchemaListing(SchemaListing):
             or super(FieldsSchemaListing, self).default_fieldset_label
         )
 
+    @property
+    def enable_unload_protection(self):
+        return False
+
     def handleModelEdit(self, action):
         self.request.response.redirect("@@modeleditor")
+
+    @button.buttonAndHandler(
+        _(u'Done'),
+    )
+    def handleDone(self, action):
+        return self.request.RESPONSE.redirect(aq_parent(self.context).absolute_url())
+
+    @button.buttonAndHandler(
+        _(u'Save Defaults'),
+        condition=lambda form: getattr(form.context, 'showSaveDefaults', True)
+    )
+    def handleSaveDefaults(self, action):
+        super(FieldsSchemaListing, self).handleSaveDefaults(self, action)
 
 
 if HAVE_RESOURCE_EDITOR:

--- a/src/collective/easyform/browser/fields.py
+++ b/src/collective/easyform/browser/fields.py
@@ -91,25 +91,15 @@ class FieldsSchemaListing(SchemaListing):
             or super(FieldsSchemaListing, self).default_fieldset_label
         )
 
-    @property
-    def enable_unload_protection(self):
-        return False
-
     def handleModelEdit(self, action):
         self.request.response.redirect("@@modeleditor")
 
     @button.buttonAndHandler(
-        _(u'Done'),
+        _(u'Save'),
     )
-    def handleDone(self, action):
-        return self.request.RESPONSE.redirect(aq_parent(self.context).absolute_url())
-
-    @button.buttonAndHandler(
-        _(u'Save Defaults'),
-        condition=lambda form: getattr(form.context, 'showSaveDefaults', True)
-    )
-    def handleSaveDefaults(self, action):
+    def handleSave(self, action):
         super(FieldsSchemaListing, self).handleSaveDefaults(self, action)
+        return self.request.RESPONSE.redirect(aq_parent(self.context).absolute_url())
 
 
 if HAVE_RESOURCE_EDITOR:


### PR DESCRIPTION
## When adding/editing fields on a form
* No need for the "Unload protection"
* When clicking the button "Done" at the bottom, send the editor back to the form, instead of remaining in the "Form fields"

## When adding/editing actions on a form
* When clicking the button "Save" at the bottom, send the editor back to the form, instead of remaining in the "Edit actions"