### PR TITLE
Port CI from master to 3.x.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: tests
+
+on:
+  push:
+    branches: [ 3.x ]
+  pull_request:
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      matrix:
+        config:
+        # [Python version, tox env]
+        - ["2.7",   "plone52-py27"]
+        - ["3.6",   "plone52-py36"]
+        - ["3.7",   "plone52-py37"]
+        - ["3.8",   "plone52-py38"]
+        - ["3.7",   "plone60-py37"]
+        - ["3.8",   "plone60-py38"]
+        - ["3.9",   "plone60-py39"]
+    runs-on: ubuntu-latest
+    name: ${{ matrix.config[1] }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.config[0] }}
+    - name: Pip cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Test
+      run: tox -e ${{ matrix.config[1] }}

--- a/base.cfg
+++ b/base.cfg
@@ -1,4 +1,57 @@
+[buildout]
+index = https://pypi.org/simple/
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
+
+show-picked-versions = true
+extensions =
+    mr.developer
+
+parts =
+    instance
+    omelette
+    releaser
+    test
+
+develop = .
+package-name = collective.easyform
+package-extras = [test,downloadxlsx]
+test-eggs =
+
+[instance]
+recipe = plone.recipe.zope2instance
+user = admin:admin
+http-address = 8080
+environment-vars =
+    zope_i18n_compile_mo_files true
+eggs =
+    Plone
+    Pillow
+    collective.easyform
+    Products.PDBDebugMode
+    pdbpp
+
+[omelette]
+recipe = collective.recipe.omelette
+eggs = ${instance:eggs}
+
+[releaser]
+recipe = zc.recipe.egg
+eggs = zest.releaser[recommended]
+
 [code-analysis]
 pre-commit-hook = False
 flake8 = True
 flake8-ignore = E501,C901,W503
+
+[versions]
+# Don't use a released version of collective.exportimport
+collective.easyform =
+plone.formwidget.hcaptcha = 1.0.1
+plone.formwidget.recaptcha = 2.3.0
+# For Buildout related packages, it is easiest to keep them at the same version for all environments.
+# Keep these empty will ensure it uses what got installed by requirements.txt
+setuptools =
+wheel =
+zc.buildout =
+pip =

--- a/bootstrap-py3.sh
+++ b/bootstrap-py3.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # see https://community.plone.org/t/not-using-bootstrap-py-as-default/620
-rm -r ./lib ./include ./local ./bin
-python3 -m venv .
-./bin/pip install -r requirements.txt
-./bin/buildout
+# rm -r ./lib ./include ./local ./bin
+python3 -m venv venv --clear
+./venv/bin/pip install -r requirements.txt
+./venv/bin/buildout bootstrap

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-zc.buildout==3.0.0b3
+setuptools==44.1.1
+zc.buildout==3.0.0rc1
+wheel==0.37.1
+pip==20.3.4

--- a/src/collective/easyform/tests/testValidators.py
+++ b/src/collective/easyform/tests/testValidators.py
@@ -29,6 +29,12 @@ from zope.interface import classImplements
 from ZPublisher.BaseRequest import BaseRequest
 from ZPublisher.HTTPRequest import FileUpload
 
+try:
+    from Products.CMFPlone.utils import get_installer
+except ImportError:
+    # BBB for Plone 5.0 and lower.
+    get_installer = None
+
 
 IFieldValidator = validators.IFieldValidator
 
@@ -460,11 +466,17 @@ class TestSingleHcaptchaValidator(LoadFixtureBase):
        Copy/paste test from Recaptcha, same api & add'on
        structure
     """
-    
+
     schema_fixture = "hcaptcha.xml"
 
     def afterSetUp(self):
         super(TestSingleHcaptchaValidator, self).afterSetUp()
+        if get_installer is None:
+            qi = self.portal["portal_quickinstaller"]
+            qi.installProducts(["plone.formwidget.hcaptcha"])
+        else:
+            qi = get_installer(self.portal)
+            qi.install_product("plone.formwidget.hcaptcha")
 
         # Put some dummy values for recaptcha
         registry = getUtility(IRegistry)

--- a/tests-5.0.x.cfg
+++ b/tests-5.0.x.cfg
@@ -1,27 +1,25 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.0.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
     base.cfg
+; parts +=
+;     createcoverage
 
-parts +=
-    createcoverage
-
-parts -=
-    code-analysis
-
-package-name = collective.easyform
-package-extras = [test,downloadxlsx]
-test-eggs =
+; parts -=
+;     code-analysis
 
 [versions]
+# block all incoming versions from the extends, we set up our env beforehand with the
+# correct versions
+pip =
 setuptools =
 zc.buildout =
-plone.app.mosaic =
-plone.app.robotframework = 1.5.0
-plone.formwidget.recaptcha = 2.1.0
-pycodestyle = 2.5.0
-flake8 = 3.7.9
-openpyxl = 2.6.3
-Pillow = 5.4.1
+wheels =
+
+; plone.app.mosaic =
+; plone.app.robotframework = 1.5.0
+; plone.formwidget.recaptcha = 2.1.0
+; pycodestyle = 2.5.0
+; flake8 = 3.7.9
+; openpyxl = 2.6.3
+; Pillow = 5.4.1

--- a/tests-5.1.x.cfg
+++ b/tests-5.1.x.cfg
@@ -1,24 +1,17 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.1.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
     base.cfg
 
-parts +=
-    createcoverage
-
-parts -=
-    code-analysis
-
-package-name = collective.easyform
-package-extras = [test,ploneformgen,downloadxlsx]
-test-eggs =
-
 [versions]
+# block all incoming versions from the extends, we set up our env beforehand with the
+# correct versions
+pip =
 setuptools =
 zc.buildout =
-plone.app.mosaic =
-plone.app.robotframework = 1.5.0
-plone.formwidget.recaptcha = 2.1.0
-openpyxl = 2.6.3
+wheels =
+
+; plone.app.mosaic =
+; plone.app.robotframework = 1.5.0
+; plone.formwidget.recaptcha = 2.1.0
+; openpyxl = 2.6.3

--- a/tests-5.2.x.cfg
+++ b/tests-5.2.x.cfg
@@ -1,42 +1,12 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-5.2.x.cfg
-    https://raw.githubusercontent.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
     base.cfg
 
-parts +=
-    createcoverage
-
-package-name = collective.easyform
-package-extras = [test,recaptcha,downloadxlsx]
-test-eggs =
-
-# Python3 compatibility for plone.formwidget.z3cform is not released
-extensions +=
-    mr.developer
-sources = sources
-sources-dir = share
-auto-checkout +=
-    plone.formwidget.recaptcha
-
 [versions]
+# block all incoming versions from the extends, we set up our env beforehand with the
+# correct versions
+pip =
 setuptools =
 zc.buildout =
-plone.app.mosaic =
-plone.app.robotframework = 1.5.0
-openpyxl = 2.6.3
-# check-manifest = 0.45 requires 'build' 0.1.0.
-# This requires a newer 'pep517' than is pinned by Plone,
-# and on Python 2.7 a newer virtualenv than is pinned by Plone.
-check-manifest = 0.44
-
-[versions:python27]
-check-manifest = 0.41
-
-[sources]
-plone.formwidget.recaptcha = git ${remotes:plone}/plone.formwidget.recaptcha.git pushurl=${remotes:plone_push}/plone.formwidget.recaptcha.git
-
-[remotes]
-plone = https://github.com/plone
-plone_push = git@github.com:plone
+wheels =

--- a/tests-6.0.x.cfg
+++ b/tests-6.0.x.cfg
@@ -1,0 +1,4 @@
+[buildout]
+extends =
+    https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
+    base.cfg

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+minversion = 3.18
+envlist =
+    plone50-py27
+    plone51-py27
+    plone52-py{27,36,37,38}
+
+[testenv]
+# We do not install with pip, but with buildout:
+usedevelop = false
+skip_install = true
+deps =
+    -r requirements.txt
+commands_pre =
+    plone50: {envbindir}/buildout -Nc {toxinidir}/tests-5.0.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone51: {envbindir}/buildout -Nc {toxinidir}/tests-5.1.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+    plone52: {envbindir}/buildout -Nc {toxinidir}/tests-5.2.x.cfg buildout:directory={envdir} buildout:develop={toxinidir} install test
+commands =
+    {envbindir}/test


### PR DESCRIPTION
Do not test on Plone 6: that only makes sense to support on master. Test on Plone 5.0, 5.1, 5.2.  All versions have errors though. Some are the same on all versions, some versions have more errors. On Plone 5.2 Python 3.8, this is the result:

```
plone52-py38 run-test: commands[0] | /Users/maurits/community/collective.easyform/.tox/plone52-py38/bin/test
Running collective.easyform.tests.base.collective.easyform:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.zope.Startup in 0.214 seconds.
  Set up plone.app.testing.layers.PloneFixture in 6.455 seconds.
  Set up plone.app.event.testing.PAEventLayer in 0.154 seconds.
  Set up plone.app.contenttypes.testing.PloneAppContenttypes in 0.098 seconds.
  Set up collective.easyform.tests.base.Fixture in 0.306 seconds.
  Set up collective.easyform.tests.base.collective.easyform:Functional in 0.000 seconds.


Failure in test /Users/maurits/community/collective.easyform/src/collective/easyform/tests/attachment.rst
Failed doctest test for attachment.rst
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/tests/attachment.rst", line 0

----------------------------------------------------------------------
File "/Users/maurits/community/collective.easyform/src/collective/easyform/tests/attachment.rst", line 176, in attachment.rst
Failed example:
    '<input id="form-buttons-download" name="form.buttons.download" class="submit-widget button-field" value="Download" type="submit" />' in browser.contents
Differences (unified diff with -expected +actual):
    @@ -1 +1 @@
    -True
    +False

  Ran 17 tests with 1 failures, 0 errors and 0 skipped in 43.712 seconds.
Running collective.easyform.tests.base.collective.easyform:Integration tests:
  Tear down collective.easyform.tests.base.collective.easyform:Functional in 0.000 seconds.
  Set up collective.easyform.tests.base.collective.easyform:Integration in 0.000 seconds.


Failure in test test_default_values_translated (collective.easyform.tests.testMisc.TestMisc)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/tests/testMisc.py", line 30, in test_default_values_translated
    self.assertEqual(self.folder.ff1.submitLabel, "Absenden")
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 912, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 1292, in assertMultiLineEqual
    self.fail(self._formatMessage(msg, standardMsg))
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 753, in fail
    raise self.failureException(msg)
AssertionError: 'Submit' != 'Absenden'
- Submit
+ Absenden




Error in test test_upgrades (collective.easyform.tests.testSetup.TestInstallation)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/tests/testSetup.py", line 158, in test_upgrades
    portal_setup.upgradeProfile(profile_id)
  File "/Users/maurits/shared-eggs/cp38/Products.GenericSetup-2.2.0-py3.8.egg/Products/GenericSetup/tool.py", line 1202, in upgradeProfile
    step.doStep(self)
  File "/Users/maurits/shared-eggs/cp38/Products.GenericSetup-2.2.0-py3.8.egg/Products/GenericSetup/upgrade.py", line 185, in doStep
    self.handler(tool)
TypeError: update_last_compilation() missing 1 required positional argument: 'timetuple'



Error in test test_no_answer (collective.easyform.tests.testValidators.TestSingleHcaptchaValidator)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/tests/testValidators.py", line 491, in test_no_answer
    form = EasyFormForm(self.ff1, request)()
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/form.py", line 233, in __call__
    self.update()
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/browser/view.py", line 314, in update
    data, errors = self.extractData()
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/group.py", line 98, in extractData
    data, errors = super(GroupForm, self).extractData(setErrors=setErrors)
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/form.py", line 148, in extractData
    data, errors = self.widgets.extract()
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/field.py", line 305, in extract
    zope.component.getMultiAdapter(
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/fields.py", line 113, in validate
    validator.validate(value)
  File "/Users/maurits/shared-eggs/cp38/plone.formwidget.hcaptcha-1.0.1-py3.8.egg/plone/formwidget/hcaptcha/validator.py", line 19, in validate
    captcha = getMultiAdapter(
  File "/Users/maurits/shared-eggs/cp38/zope.component-4.6.2-py3.8.egg/zope/component/_api.py", line 104, in getMultiAdapter
    raise ComponentLookupError(objects, interface, name)
zope.interface.interfaces.ComponentLookupError: ((<EasyForm at /plone/test-folder/ff1>, <HTTPRequest, URL=http://nohost>), <InterfaceClass zope.interface.Interface>, 'hcaptcha')



Error in test test_wrong (collective.easyform.tests.testValidators.TestSingleHcaptchaValidator)
Traceback (most recent call last):
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/Users/maurits/.pyenv/versions/3.8.12/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/tests/testValidators.py", line 499, in test_wrong
    form = EasyFormForm(self.ff1, request)()
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/form.py", line 233, in __call__
    self.update()
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/browser/view.py", line 314, in update
    data, errors = self.extractData()
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/group.py", line 98, in extractData
    data, errors = super(GroupForm, self).extractData(setErrors=setErrors)
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/form.py", line 148, in extractData
    data, errors = self.widgets.extract()
  File "/Users/maurits/shared-eggs/cp38/z3c.form-3.7.1-py3.8.egg/z3c/form/field.py", line 305, in extract
    zope.component.getMultiAdapter(
  File "/Users/maurits/community/collective.easyform/src/collective/easyform/fields.py", line 113, in validate
    validator.validate(value)
  File "/Users/maurits/shared-eggs/cp38/plone.formwidget.hcaptcha-1.0.1-py3.8.egg/plone/formwidget/hcaptcha/validator.py", line 19, in validate
    captcha = getMultiAdapter(
  File "/Users/maurits/shared-eggs/cp38/zope.component-4.6.2-py3.8.egg/zope/component/_api.py", line 104, in getMultiAdapter
    raise ComponentLookupError(objects, interface, name)
zope.interface.interfaces.ComponentLookupError: ((<EasyForm at /plone/test-folder/ff1>, <HTTPRequest, URL=http://nohost>), <InterfaceClass zope.interface.Interface>, 'hcaptcha')

  Ran 133 tests with 1 failures, 3 errors and 0 skipped in 13.349 seconds.
```