### PR TITLE
Use specific permission for displaying/downloading saved data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ New features:
 - Add French translations
   [mpeeters, laulaz]
 
+- Use ``collective.easyform.DownloadSavedInput`` permission for displaying/downloading saved data (#357)
+  [laulaz]
+
 Bug fixes:
 
 - Fix persistence issue with SaveData storage.

--- a/src/collective/easyform/browser/actions.zcml
+++ b/src/collective/easyform/browser/actions.zcml
@@ -11,7 +11,7 @@
   <browser:page
       name="saveddata"
       for="collective.easyform.interfaces.IEasyForm"
-      permission="cmf.ModifyPortalContent"
+      permission="collective.easyform.DownloadSavedInput"
       class=".actions.SavedDataView"
       template="saveddata.pt"
       />
@@ -47,7 +47,7 @@
   <browser:page
       name="data"
       for="collective.easyform.interfaces.IEasyFormActionContext"
-      permission="cmf.ModifyPortalContent"
+      permission="collective.easyform.DownloadSavedInput"
       class=".actions.ActionSavedDataView"
       layer="..interfaces.IEasyFormLayer"
       />

--- a/src/collective/easyform/profiles/default/actions.xml
+++ b/src/collective/easyform/profiles/default/actions.xml
@@ -79,7 +79,7 @@
       <property name="icon_expr" />
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
-        <element value="Modify portal content" />
+        <element value="collective.easyform: Download Saved Input" />
       </property>
       <property name="visible">True</property>
     </object>

--- a/src/collective/easyform/profiles/default/metadata.xml
+++ b/src/collective/easyform/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1011</version>
+  <version>1012</version>
 </metadata>

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -3,6 +3,7 @@
 # Integration tests specific to save-data adapter.
 #
 
+from AccessControl.unauthorized import Unauthorized
 from collective.easyform.api import get_actions
 from collective.easyform.api import get_schema
 from collective.easyform.interfaces import ISaveData
@@ -10,17 +11,23 @@ from collective.easyform.tests import base
 from os.path import dirname
 from os.path import join
 from plone import api
+from plone.app.testing import login
+from plone.app.testing import logout
+from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
 from plone.app.testing import SITE_OWNER_PASSWORD
+from plone.app.testing import TEST_USER_ID
 from plone.testing.zope import Browser
 from six import BytesIO
 from six.moves import zip
 from transaction import commit
+from zExceptions.unauthorized import Unauthorized as zUnauthorized
 from ZPublisher.HTTPRequest import HTTPRequest
 from ZPublisher.HTTPResponse import HTTPResponse
 
 import plone.protect
 import sys
+import transaction
 import unittest
 
 try:
@@ -80,6 +87,21 @@ class SaveDataTestCase(base.EasyFormTestCase):
 
         view = self.ff1.restrictedTraverse("saveddata")
         self.assertEqual(list(view.items()), [("saver", u"Saver")])
+
+        # as the owner, TEST_USER_ID can still see the saved data
+        setRoles(self.portal, TEST_USER_ID, [])
+        view = self.ff1.restrictedTraverse("saveddata")
+        self.assertIsNotNone(view)
+        logout()
+
+        # other editors / reviewers / ... don't have access to the saved data
+        api.user.create(email="test@plone.org", username="test")
+        setRoles(
+            self.portal, "test", roles=["Reader", "Contributor", "Editor", "Reviewer"]
+        )
+        login(self.portal, "test")
+        with self.assertRaises(Unauthorized):
+            view = self.ff1.restrictedTraverse("saveddata")
 
     def testSaverDataFormExtraData(self):
         """test saver data form extra data"""
@@ -647,6 +669,26 @@ class SaverIntegrationTestCase(base.EasyFormFunctionalTestCase):
         # 2. Check that creation succeeded
         actions = get_actions(self.ff1)
         self.assertTrue("saver" in actions)
+
+    def test_download_saveddata_view(self):
+        self.browser.open(self.portal_url + "/test-folder/ff1/@@actions/saver/@@data")
+        self.assertTrue("Saved Data" in self.browser.contents)
+        self.assertTrue(
+            "viewpermission-collective-easyform-download-saved-input"
+            in self.browser.contents
+        )
+
+        # editors / reviewers / ... don't have access to the saved data
+        api.user.create(email="test@plone.org", username="test", password="password")
+        setRoles(
+            self.portal, "test", roles=["Reader", "Contributor", "Editor", "Reviewer"]
+        )
+        self.browser.addHeader("Authorization", "Basic " + "test" + ":" + "password")
+        transaction.commit()
+        with self.assertRaises(zUnauthorized):
+            self.browser.open(
+                self.portal_url + "/test-folder/ff1/@@actions/saver/@@data"
+            )
 
     def test_download_saveddata_suggests_csv_delimiter_default_registry_value(self):
         self.browser.open(self.portal_url + "/test-folder/ff1/@@actions/saver/@@data")

--- a/src/collective/easyform/upgrades/1012.zcml
+++ b/src/collective/easyform/upgrades/1012.zcml
@@ -1,0 +1,17 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    >
+
+  <gs:upgradeSteps
+      destination="1012"
+      profile="collective.easyform:default"
+      source="1011"
+      >
+    <gs:upgradeStep
+        title="Change permission of 'Saved data' action"
+        handler=".change_saveddata_action_permission"
+        />
+  </gs:upgradeSteps>
+
+</configure>

--- a/src/collective/easyform/upgrades/__init__.py
+++ b/src/collective/easyform/upgrades/__init__.py
@@ -68,3 +68,14 @@ def fix_savedata_persistence_issues(context):
             logger.info(
                 'Fixed storage of {}'.format('/'.join(form.getPhysicalPath()))
             )
+
+
+def change_saveddata_action_permission(context):
+    portal_actions = api.portal.get_tool("portal_actions")
+    category = portal_actions.get("object_buttons")
+    if category is None:
+        return
+    action = category.get("saveddata")
+    if action is None:
+        return
+    action._setPropValue('permissions', ("collective.easyform: Download Saved Input",))

--- a/src/collective/easyform/upgrades/configure.zcml
+++ b/src/collective/easyform/upgrades/configure.zcml
@@ -10,5 +10,6 @@
   <include file="1009.zcml" />
   <include file="1010.zcml" />
   <include file="1011.zcml" />
+  <include file="1012.zcml" />
 
 </configure>


### PR DESCRIPTION
`collective.easyform.DownloadSavedInput` is set by default for Owner, Manager and Site Administrator roles

This refs #357