### PR TITLE
Use "|" as delimiter of list types in exports. (3.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use "|" as delimiter of list types in exports. [mathias.leimgruber]
 
 
 3.1.1 (2022-06-20)

--- a/src/collective/easyform/actions.py
+++ b/src/collective/easyform/actions.py
@@ -661,6 +661,9 @@ class SaveData(Action):
                 data = data.filename
             if six.PY2 and isinstance(data, six.text_type):
                 return data.encode("utf-8")
+            if isinstance(data, (list, tuple, set)):
+                data = '|'.join(data)
+                return data.encode('utf-8')
             return data
 
         return [get_data(row, i) for i in names]

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -326,7 +326,7 @@ class SaveDataTestCase(base.EasyFormTestCase):
         self.assertEqual(rows[1][0].value, "test@test.org")
         self.assertEqual(rows[1][1].value, "test subject")
         self.assertEqual(rows[1][2].value, "test comments")
-        self.assertEqual(rows[1][3].value, '["Red", "Blue"]')
+        self.assertEqual(rows[1][3].value, 'Red|Blue')
 
     def testSaverDownloadWithTitles(self):
         """test save data"""


### PR DESCRIPTION
This makes the for example multiple choice fields in Excel/Spreadsheets
way more controllable.

Example:
<img width="464" alt="Screenshot 2022-07-19 at 11 16 46" src="https://user-images.githubusercontent.com/437933/179786680-37723e5e-8cb4-4d05-abf5-4bbfc7c3522c.png">

