### PR TITLE
Use "|" as delimiter of list types in exports. (4.x)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ New features:
 - restapi (de)serializer that includes saved data
   [ThibautBorn, gotcha, Mychae1]
 
+- Use "|" as delimiter of list types in exports. [mathias.leimgruber]
+
+
 Bug fixes:
 
 - Fix persistence issue with SaveData storage.

--- a/src/collective/easyform/actions.py
+++ b/src/collective/easyform/actions.py
@@ -697,6 +697,10 @@ class SaveData(Action):
                 data = data.filename
             if six.PY2 and isinstance(data, six.text_type):
                 return data.encode("utf-8")
+            if isinstance(data, (list, tuple, set)):
+                data = '|'.join(data)
+                if six.PY2:
+                    return data.encode('utf-8')
             return data
 
         return [get_data(row, i) for i in names]

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -320,7 +320,7 @@ class SaveDataTestCase(BaseSaveData):
             topic="test subject",
             replyto="test@test.org",
             comments="test comments",
-            multiplechoice=[u"Red", u"Blue"]
+            multiplechoice=["Red", "Blue"]
         )
         saver.onSuccess(request.form, request)
 
@@ -346,7 +346,7 @@ class SaveDataTestCase(BaseSaveData):
         self.assertEqual(rows[1][0].value, "test@test.org")
         self.assertEqual(rows[1][1].value, "test subject")
         self.assertEqual(rows[1][2].value, "test comments")
-        self.assertEqual(rows[1][3].value, '["Red", "Blue"]')
+        self.assertEqual(rows[1][3].value, "Red|Blue")
 
     def testSaverDownloadWithTitles(self):
         """test save data"""


### PR DESCRIPTION
This makes the for example multiple choice fields in Excel/Spreadsheets
way more controllable.

Example
<img width="464" alt="Screenshot 2022-07-19 at 11 16 46" src="https://user-images.githubusercontent.com/437933/179786862-3a205271-4fed-45ee-820f-0b733e499e88.png">

