### PR TITLE
Implement onDisplayOverride TALES field

### DIFF
--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -381,6 +381,18 @@ class EasyFormForm(AutoExtensibleForm, form.Form):
             return self.context.nameAttribute
         return None
 
+    def getOnDisplayOverride(self):
+        """Evaluate form setup script TALES expression stored in the
+        onDisplayOverride field if defined
+        """
+        if self.context.onDisplayOverride:
+            get_expression(self.context, self.context.onDisplayOverride)
+
+    def render(self):
+        self.getOnDisplayOverride()
+        self.updateWidgets()
+        return super(EasyFormForm, self).render()
+
 
 class EasyFormFormWrapper(FormWrapper):
     form = EasyFormForm


### PR DESCRIPTION
The onDisplayOverride field is present in collective.easyform, but is currently not implemented (related to issue #184 ).
This PR adds code to invoke it before rendering.