### PR TITLE
Fix xml schema editor for fields and actions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,10 @@ Changelog
 4.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix xml schema editor for fields and actions.
+  Fixes `issue 366 <https://github.com/collective/collective.easyform/issues/366>`_.
+  [maurits]
+
 
 
 4.1.1 (2022-10-28)
@@ -76,7 +79,7 @@ Enhancements:
 
 Breaking change:
 
-- This is for Plone 6 only. At least this is the only version that is tested. 
+- This is for Plone 6 only. At least this is the only version that is tested.
   (Changelog edited later to avoid misunderstandings, use 3.x for Plone 5.2)
   [maurits]
 

--- a/src/collective/easyform/browser/fields.py
+++ b/src/collective/easyform/browser/fields.py
@@ -18,6 +18,7 @@ from plone.schemaeditor.browser.schema.traversal import SchemaContext
 from plone.supermodel import loadString
 from plone.supermodel.parser import SupermodelParseError
 from Products.CMFPlone.utils import safe_bytes
+from Products.CMFPlone.utils import safe_text
 from Products.Five import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button

--- a/src/collective/easyform/browser/modeleditor.pt
+++ b/src/collective/easyform/browser/modeleditor.pt
@@ -51,7 +51,7 @@
               <textarea
                   name="source"
                   class="modeleditor__source pat-code-editor"
-                  data-pat-code-editor="language: xml; theme: okaidia">${view/modelSource}</textarea>
+                  data-pat-code-editor="language: xml; theme: okaidia">${view/escaped_model_source}</textarea>
 
             </form>
           </div>

--- a/src/collective/easyform/browser/modeleditor.pt
+++ b/src/collective/easyform/browser/modeleditor.pt
@@ -12,9 +12,6 @@
     <metal:main fill-slot="content">
       <tal:main-macro metal:define-macro="content">
         <div id="content">
-          <style type="text/css"
-                 tal:content="string:@import url(${portal_url}/++resource++plone.app.dexterity.modeleditor.css);"
-          ></style>
           <div id="page-intro">
             <h1 class="documentFirstHeading"
                 tal:content="view/title"


### PR DESCRIPTION
Fixes https://github.com/collective/collective.easyform/issues/366. Please check, it is easy to overlook some use cases.
Done in the same way as I did today for the (dexterity) Types control panel: https://github.com/plone/plone.app.dexterity/pull/356

Our `ModelEditorView` class is mostly a copy of the p.a.dexterity one. I took over some changes, so the code is more similar now. We could inherit from that one, and override only a few methods, but that would require my other PR to be merged and released, and preferably be included in a Plone release. So this may be for later.