### PR TITLE
Make dependencies and css_class work in fieldsets as well.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 4.1.2 (unreleased)
 ------------------
 
+- Make dependencies and css_class work in fieldsets as well.
+  Note that this overrides ``widget.pt`` from ``plone.app.z3cform`` for *all* forms.
+  Should be okay: they are currently very similar.
+  [maurits]
+
 - Fix xml schema editor for fields and actions.
   Fixes `issue 366 <https://github.com/collective/collective.easyform/issues/366>`_.
   [maurits]

--- a/src/collective/easyform/browser/widget.pt
+++ b/src/collective/easyform/browser/widget.pt
@@ -6,13 +6,14 @@
                error_class python:error and ' error' or '';
                empty_values python: (None, '', [], ('', '', '', '00', '00', ''), ('', '', ''));
                empty_class python: (widget.value in empty_values) and ' empty' or '';
-               dependencies view/@@dependencies;
+               dependencies view/@@dependencies|nothing;
                pat_depends_class python: dependencies and 'pat-depends'"
    data-pat-inlinevalidation='{"type":"z3c.form"}'
    data-pat-depends="${dependencies}"
    id="formfield-${python:widget.id}"
-   class="field fieldname-${python:widget.name} widget-mode-${python:widget.mode}${error_class}${empty_class} ${python:getattr(widget, 'wrapper_css_class', '') or ''} ${view/@@css_class} ${pat_depends_class}"
+   class="field fieldname-${python:widget.name} widget-mode-${python:widget.mode}${error_class}${empty_class} ${python:getattr(widget, 'wrapper_css_class', '') or ''} ${view/@@css_class|nothing} ${pat_depends_class}"
    data-fieldname="${widget/name}">
+
     <label for="${python:widget.id}"
             class="form-label"
             tal:condition="python: widget.mode == 'input' and widget.label">

--- a/src/collective/easyform/browser/widgets.py
+++ b/src/collective/easyform/browser/widgets.py
@@ -3,6 +3,7 @@
 from collective.easyform.interfaces import ILabelWidget
 from collective.easyform.interfaces import IRenderWidget
 from collective.easyform.interfaces import IRichLabelWidget
+from plone.app.z3cform.views import RenderWidget as PloneRenderWidget
 from Products.Five.browser import BrowserView
 from Products.Five.browser.metaconfigure import ViewMixinForTemplates
 from z3c.form import interfaces
@@ -17,6 +18,11 @@ from zope.interface import implementer_only
 from zope.interface import Interface
 from zope.publisher.interfaces.browser import IBrowserView
 from zope.schema.interfaces import IField
+
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 @implementer_only(ILabelWidget)
@@ -106,3 +112,19 @@ class WidgetCssClassView(object):
         if not css_class:
             return dflt
         return css_class
+
+
+PloneRenderWidget.index = ViewPageTemplateFile("widget.pt")
+logger.info("Patched plone.app.z3cform.views.RenderWidget to use our widget.pt.")
+
+
+@adapter(PloneRenderWidget, Interface)
+@implementer(IBrowserView)
+class PloneWidgetDependencyView(WidgetDependencyView):
+    pass
+
+
+@adapter(PloneRenderWidget, Interface)
+@implementer(IBrowserView)
+class PloneWidgetCssClassView(WidgetCssClassView):
+    pass

--- a/src/collective/easyform/browser/widgets.zcml
+++ b/src/collective/easyform/browser/widgets.zcml
@@ -104,9 +104,17 @@
       factory=".widgets.WidgetDependencyView"
       name="dependencies"
       />
+  <adapter
+      factory=".widgets.PloneWidgetDependencyView"
+      name="dependencies"
+      />
 
   <adapter
       factory=".widgets.WidgetCssClassView"
+      name="css_class"
+      />
+  <adapter
+      factory=".widgets.PloneWidgetCssClassView"
       name="css_class"
       />
 


### PR DESCRIPTION
Note that this overrides `widget.pt` from `plone.app.z3cform` for *all* forms. Should be okay: they are currently very similar.  Differences:

- We lookup `@@dependencies` and `@@css_class` views on the widget, though we now accept it when these are not found.
- We set `data-pat-inlinevalidation='{"type":"z3c.form"}'`

This PR is targeted at my branch for PR #387, because we may need both changes in a project. The commit specific for the current PR should be cleanly applicable on the master branch, except perhaps the changelog entry.