### PR TITLE
Fix IEasyFormWidget marker for GroupForm widgets (take 2)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,9 @@ Changelog
 - Schemaeditor UI: close modals and reload fields(sets) when saving.
   [petschki]
 
+- Fix bug which did not render correctly GroupForm widgets (see #370)
+  [petschki]
+
 
 4.1.0 (2022-08-10)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "plone.schema",
         "plone.schemaeditor>=4.0.0b1",
         "plone.supermodel",
+        "plone.restapi",
         "Products.CMFPlone>=6.0.0b1",
         "Products.validation",
         "setuptools",

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -300,12 +300,14 @@ class EasyFormForm(AutoExtensibleForm, form.Form):
         if "reset" in self.actions:
             self.actions["reset"].title = self.context.resetLabel
 
-    def updateWidgets(self):
-        super(EasyFormForm, self).updateWidgets()
+    def markWidgets(self):
         for w in self.widgets.values():
             if not IEasyFormWidget.providedBy(w):
-                # add marker for custom widget renderer
                 alsoProvides(w, IEasyFormWidget)
+        for g in self.groups:
+            for w in g.widgets.values():
+                if not IEasyFormWidget.providedBy(w):
+                    alsoProvides(w, IEasyFormWidget)
 
     def formMaybeForceSSL(self):
         """Redirect to an https:// URL if the 'force SSL' option is on.
@@ -328,6 +330,7 @@ class EasyFormForm(AutoExtensibleForm, form.Form):
         """Update form - see interfaces.IForm"""
         self.formMaybeForceSSL()
         super(EasyFormForm, self).update()
+        self.markWidgets()
         self.template = self.form_template
         if self.request.method != "POST" or self.context.thanksPageOverride:
             # go with all but default thank you page rendering


### PR DESCRIPTION
This cherry-picks three commits from PR #374 by @petschki.
That PR has too many conflicting files now, due to introducing mxdev (and a 300 line Makefile which I am still not a fan of) and doing black/isort. This could be retried in a separate PR. The tests pass locally.
Fixes issue #370.