### PR TITLE
Missing server side variable in custom script adapters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 4.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- fix absence in custom script adapters space of server side flagged field
+  [sauzher]
 
 
 4.1.2 (2023-01-02)

--- a/src/collective/easyform/actions.py
+++ b/src/collective/easyform/actions.py
@@ -584,7 +584,7 @@ class CustomScript(Action):
         script.ZPythonScript_edit(params, body)
         return script
 
-    def sanifyFields(self, form):
+    def sanifyFields(self, form, fields):
         # Makes request.form fields accessible in a script
         #
         # Avoid Unauthorized exceptions since request.form is inaccesible
@@ -592,6 +592,12 @@ class CustomScript(Action):
         result = {}
         for field in form:
             result[field] = form[field]
+
+        # append in the results all serverside fields variable
+        for field in fields:
+            key = 'form.widgets.{}'.format(field)
+            if key not in result:
+                result[field] = fields[field]
         return result
 
     def checkWarningsAndErrors(self, script):
@@ -638,7 +644,7 @@ class CustomScript(Action):
     def onSuccess(self, fields, request):
         # Executes the custom script
         form = get_context(self)
-        resultData = self.sanifyFields(request.form)
+        resultData = self.sanifyFields(request.form, fields)
         return self.executeCustomScript(resultData, form, request)
 
 


### PR DESCRIPTION
Fix #396 
Custom script adapters was unable to access those fields checked as "Server-Side Variable" despite of the description of that field parameter https://github.com/collective/collective.easyform/blob/77fbd602422bccafe617c9731626f9065ba7289d/src/collective/easyform/interfaces/fields.py#L175-L179

