### PR TITLE
Add icon expressions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 
 Bug fixes:
 
+- Add upgrade step and profile to update contenttype icon in registry.
+  [maurits]
+
 - Add icon expressions for actions.
   [maurits]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 
 Bug fixes:
 
+- Add icon expressions for actions.
+  [maurits]
+
 - Update Spanish translations.
   [macagua]
 

--- a/src/collective/easyform/profiles/default/actions.xml
+++ b/src/collective/easyform/profiles/default/actions.xml
@@ -18,7 +18,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('')</property>
-      <property name="icon_expr" />
+      <property name="icon_expr">string:ui-checks</property>
       <property name="available_expr">python:object.portal_type == 'EasyForm' and object.restrictedTraverse('@@is-sub-easyform')()</property>
       <property name="permissions">
         <element value="Manage portal" />
@@ -40,7 +40,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@export-easyform')</property>
-      <property name="icon_expr" />
+      <property name="icon_expr">string:box-arrow-right</property>
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
         <element value="Manage portal" />
@@ -58,7 +58,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@import-easyform')</property>
-      <property name="icon_expr" />
+      <property name="icon_expr">string:box-arrow-in-left</property>
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
         <element value="Manage portal" />
@@ -76,7 +76,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('@@saveddata')</property>
-      <property name="icon_expr" />
+      <property name="icon_expr">string:database</property>
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
         <element value="collective.easyform: Download Saved Input" />
@@ -94,7 +94,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('fields')</property>
-      <property name="icon_expr" />
+      <property name="icon_expr">string:list</property>
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
         <element value="Modify portal content" />
@@ -112,7 +112,7 @@
                 i18n:translate=""
       />
       <property name="url_expr">python:context.restrictedTraverse('@@get-easyform-url')('actions')</property>
-      <property name="icon_expr" />
+      <property name="icon_expr">string:list-check</property>
       <property name="available_expr">python:object.portal_type == 'EasyForm'</property>
       <property name="permissions">
         <element value="Modify portal content" />

--- a/src/collective/easyform/profiles/default/metadata.xml
+++ b/src/collective/easyform/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1015</version>
+  <version>1016</version>
 </metadata>

--- a/src/collective/easyform/setuphandlers.py
+++ b/src/collective/easyform/setuphandlers.py
@@ -6,5 +6,16 @@ from zope.interface import implementer
 @implementer(INonInstallable)
 class HiddenProfiles(object):
     def getNonInstallableProfiles(self):
-        """Hide uninstall profile from site-creation and quickinstaller."""
+        """Hide uninstall profile from site-creation and installer."""
         return ["collective.easyform:uninstall"]
+
+    def getNonInstallableProducts(self):
+        """Hide the upgrades package from site-creation and installer.
+
+        Our upgrades profiles are defined in the directory 'upgrades'.
+        Plone sees this as a separate product.
+        So instead of adding each new upgrade profile to the list of
+        non installable profiles above, we can mark the upgrades product
+        as non installable.
+        """
+        return ["collective.easyform.upgrades"]

--- a/src/collective/easyform/upgrades/1016.zcml
+++ b/src/collective/easyform/upgrades/1016.zcml
@@ -1,0 +1,19 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:gs="http://namespaces.zope.org/genericsetup"
+    >
+
+  <gs:upgradeSteps
+      destination="1016"
+      profile="collective.easyform:default"
+      source="1015"
+      >
+
+    <gs:upgradeDepends
+        title="Apply actions definition from default profile"
+        import_steps="actions"
+        />
+
+  </gs:upgradeSteps>
+
+</configure>

--- a/src/collective/easyform/upgrades/1016.zcml
+++ b/src/collective/easyform/upgrades/1016.zcml
@@ -3,11 +3,24 @@
     xmlns:gs="http://namespaces.zope.org/genericsetup"
     >
 
+  <gs:registerProfile
+      directory="profiles/1016"
+      for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
+      name="1016"
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      title="EasyForm upgrade"
+      />
+
   <gs:upgradeSteps
       destination="1016"
       profile="collective.easyform:default"
       source="1015"
       >
+
+    <gs:upgradeDepends
+        title="Upgrade contenttype icon in registry"
+        import_profile="collective.easyform.upgrades:1016"
+        />
 
     <gs:upgradeDepends
         title="Apply actions definition from default profile"

--- a/src/collective/easyform/upgrades/1016.zcml
+++ b/src/collective/easyform/upgrades/1016.zcml
@@ -22,11 +22,6 @@
         import_profile="collective.easyform.upgrades:1016"
         />
 
-    <gs:upgradeDepends
-        title="Apply actions definition from default profile"
-        import_steps="actions"
-        />
-
   </gs:upgradeSteps>
 
 </configure>

--- a/src/collective/easyform/upgrades/configure.zcml
+++ b/src/collective/easyform/upgrades/configure.zcml
@@ -14,5 +14,6 @@
   <include file="1013.zcml" />
   <include file="1014.zcml" />
   <include file="1015.zcml" />
+  <include file="1016.zcml" />
 
 </configure>

--- a/src/collective/easyform/upgrades/profiles/1016/actions.xml
+++ b/src/collective/easyform/upgrades/profiles/1016/actions.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Plone Actions Tool"
+        name="portal_actions"
+>
+  <object meta_type="CMF Action Category"
+          name="object"
+  >
+    <object meta_type="CMF Action"
+            name="easyform-view"
+            i18n:domain="collective.easyform"
+    >
+      <property name="icon_expr">string:ui-checks</property>
+    </object>
+  </object>
+  <object meta_type="CMF Action Category"
+          name="object_buttons"
+  >
+    <object meta_type="CMF Action"
+            name="export"
+            i18n:domain="collective.easyform"
+    >
+      <property name="icon_expr">string:box-arrow-right</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="import"
+            i18n:domain="collective.easyform"
+    >
+      <property name="icon_expr">string:box-arrow-in-left</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="saveddata"
+            i18n:domain="collective.easyform"
+    >
+      <property name="icon_expr">string:database</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="Fields"
+            i18n:domain="collective.easyform"
+    >
+      <property name="icon_expr">string:list</property>
+    </object>
+    <object meta_type="CMF Action"
+            name="Actions"
+            i18n:domain="collective.easyform"
+    >
+      <property name="icon_expr">string:list-check</property>
+    </object>
+  </object>
+</object>

--- a/src/collective/easyform/upgrades/profiles/1016/registry.xml
+++ b/src/collective/easyform/upgrades/profiles/1016/registry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<registry>
+
+  <record name="plone.icon.contenttype/easyform">
+    <field type="plone.registry.field.TextLine">
+      <title>Easyform</title>
+    </field>
+    <value key="resource">++plone++bootstrap-icons/ui-checks.svg</value>
+  </record>
+
+</registry>


### PR DESCRIPTION
In the actions dropdown, before:

![Screenshot 2023-02-28 at 13 52 07](https://user-images.githubusercontent.com/210587/221877818-a872cfda-f1e1-4ee9-848d-99a5f792d73e.png)

after:

![Screenshot 2023-02-28 at 13 52 22](https://user-images.githubusercontent.com/210587/221877874-8182a55b-d93c-4948-b664-28e970dc4c0a.png)

Includes upgrade step.

Also, a content type icon was added by @frapell last year in commit 11f5ba4b64a92fd2bfa0cc4e33c2ce0d68ff53c4, but there was no upgrade step.  I added it here.  See comments in that commit for why this icon would ideally not be needed, and Plone should reuse the FTI icon instead.  But currently it still is needed, so let's have an upgrade step.




