### PR TITLE
Migrate ReCaptcha field to not required

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 4.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- make ReCaptcha fields not required during PloneFormGen migration [ThibautBorn]
 
 
 4.1.3 (2023-05-16)

--- a/src/collective/easyform/migration/fields.py
+++ b/src/collective/easyform/migration/fields.py
@@ -167,7 +167,7 @@ TYPES_MAPPING = {
         "collective.easyform.fields.RichLabel", append_label_field
     ),
     "FormFileField": Type("plone.namedfile.field.NamedBlobFile", append_field),
-    "FormCaptchaField": Type("collective.easyform.fields.ReCaptcha", append_field),
+    "FormCaptchaField": Type("collective.easyform.fields.ReCaptcha", append_label_field),
     "FormLikertField": Type("collective.easyform.fields.Likert", append_field),
     "FieldsetStart": Type("", append_fieldset),
     "FieldsetEnd": Type("", None),

--- a/src/collective/easyform/tests/testValidators.py
+++ b/src/collective/easyform/tests/testValidators.py
@@ -493,7 +493,7 @@ class TestSingleHcaptchaValidator(LoadFixtureBase):
         request = self.LoadRequestForm(**data)
         request.method = "POST"
         form = EasyFormForm(self.ff1, request)()
-        self.assertIn("<div class=\"invalid-feedback\">", form)
+        self.assertIn("class=\"invalid-feedback\"", form)
         self.assertNotIn("Thanks for your input.", form)
 
     def test_wrong(self):
@@ -501,7 +501,7 @@ class TestSingleHcaptchaValidator(LoadFixtureBase):
         request = self.LoadRequestForm(**data)
         request.method = "POST"
         form = EasyFormForm(self.ff1, request)()
-        self.assertIn("<div class=\"invalid-feedback\">", form)
+        self.assertIn("class=\"invalid-feedback\"", form)
         self.assertNotIn("Thanks for your input.", form)
 
 


### PR DESCRIPTION
context: ReCaptcha fields may not be required in easyform