### PR TITLE
folder_contents accessible from saveddata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 4.1.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- fix folder_contents accessibility from @@saveddata. [ThibautBorn]
+
 
 
 4.1.3 (2023-05-16)

--- a/src/collective/easyform/browser/configure.zcml
+++ b/src/collective/easyform/browser/configure.zcml
@@ -51,6 +51,12 @@
       permission="zope2.View"
       class=".view.FolderContentsView"
       />
+  <browser:page
+      name="folder_contents"
+      for="collective.easyform.browser.actions.EasyFormActionsView"
+      permission="zope2.View"
+      class=".view.FolderContentsView"
+      />
   <configure zcml:condition="installed plone.dexterity.exportimport">
     <browser:page
         name="export-easyform"


### PR DESCRIPTION
context: the contents link in the toolbar from saveddata view was broken

This issue was already discussed and solved [here](https://github.com/collective/collective.easyform/issues/219): but the folder_contents link was broken for  the saveddata view

Note: there is already a fix for broken tests included in https://github.com/collective/collective.easyform/pull/407