### PR TITLE
enable changing shortname behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add plone.shortname behaviour to EasyForm type.
+  [ThibautBorn]
 
 
 4.2.0 (2024-03-15)

--- a/src/collective/easyform/profiles/default/types/EasyForm.xml
+++ b/src/collective/easyform/profiles/default/types/EasyForm.xml
@@ -25,6 +25,7 @@
     <element value="plone.namefromtitle" />
     <element value="plone.allowdiscussion" />
     <element value="plone.excludefromnavigation" />
+    <element value="plone.shortname" />
     <element value="plone.dublincore" />
   </property>
 

--- a/src/collective/easyform/upgrades/1017.zcml
+++ b/src/collective/easyform/upgrades/1017.zcml
@@ -18,7 +18,7 @@
       >
 
     <gs:upgradeDepends
-        title="Add max filesize in registry"
+        title="Add max filesize in registry and plone.shortname behavior to form."
         import_profile="collective.easyform.upgrades:1017"
         />
 

--- a/src/collective/easyform/upgrades/profiles/1017/types/EasyForm.xml
+++ b/src/collective/easyform/upgrades/profiles/1017/types/EasyForm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        meta_type="Dexterity FTI"
+        name="EasyForm"
+        i18n:domain="collective.easyform"
+>
+  <property name="behaviors" purge="False">
+    <element value="plone.shortname" />
+  </property>
+</object>


### PR DESCRIPTION
This behavior wasn't enabled by default for easyform. It makes sense to enable it, as this behavior is often enabled by default (e.g. plone.app.contenttypes) 