### PR TITLE
fix(ISSUE-279): :bug: set fieldset description as attribute, not node, when migrating from PFG

### DIFF
--- a/news/279.bugfix
+++ b/news/279.bugfix
@@ -1,0 +1,2 @@
+Set fieldset description as attribute, not node, when migrating from PFG.
+[thomasmassmann]

--- a/src/collective/easyform/migration/fields.py
+++ b/src/collective/easyform/migration/fields.py
@@ -128,6 +128,13 @@ def append_or_set_title(field, name, value):
         append_node(field, name, value)
 
 
+def append_or_set_description(field, name, value):
+    if field.tag == 'fieldset':
+        set_attribute(field, 'description', value)
+    else:
+        append_node(field, name, value)
+
+
 def convert_tales_expressions(value):
     if value == u"here/memberEmail":
         return u"python:member and member.getProperty('email', '') or ''"
@@ -174,7 +181,7 @@ TYPES_MAPPING = {
 }
 
 PROPERTIES_MAPPING = {
-    "description": Property("description", append_node),
+    "description": Property("description", append_or_set_description),
     "likertQuestions": Property("questions", append_list_node),
     "likertAnswers": Property("answers", append_list_node),
     "fgDefault": Property("default", append_default_node),


### PR DESCRIPTION
This fixes #279 

Obsoletes: https://github.com/collective/collective.easyform/pull/280

I made this fork in order to be able to rebase and force-push and merge, which I cannot do on thomas' branch.