### PR TITLE
Fix Plone 5 related upgrade steps in Plone 6.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 4.2.1 (unreleased)
 ------------------
 
+- Fix Plone 5 related upgrade steps in Plone 6.
+  [thet]
+
 - Add plone.shortname behaviour to EasyForm type.
   [ThibautBorn]
 

--- a/src/collective/easyform/upgrades/__init__.py
+++ b/src/collective/easyform/upgrades/__init__.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 from plone import api
 
 import logging
@@ -5,8 +6,18 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+HAS_PLONE_6 = getattr(
+    import_module("Products.CMFPlone.factory"), "PLONE60MARKER", False
+)
+
 
 def update_last_compilation(context, timetuple=None):
+    if HAS_PLONE_6:
+        # No need to update the `last_compilation` time on Plone 6.
+        # The resources are refreshed with every restart of the instance
+        # automatically.
+        return
+
     # Let's do the imports inline, so they are not needlessly done at startup.
     # Should not really matter, but oh well.
     from datetime import datetime


### PR DESCRIPTION
When upgrading from Plone 5 to Plone 6, the upgrade broke with:

```
2024-10-08 13:18:11,350 INFO    [ftw.upgrade:177][waitress-0] ______________________________________________________________________
2024-10-08 13:18:11,351 INFO    [ftw.upgrade:178][waitress-0] UPGRADE STEP collective.easyform:default: Update last_compilation of bundle
2024-10-08 13:18:11,351 ERROR   [ftw.upgrade:39][waitress-0] FAILED

```

We're not using the `last_compilation` registry entry anymore, thankfully.

This PR fixes that by just ignoring the `last_compilation` update method in Plone 6.