### PR TITLE
Add Advanced config to remove autofocus on firt input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@ Changelog
 
 - Pin version `Products.validation>=3.0.0`
   [petschki]
+- Add a checkbox to disable autofocus on the first input
+  [yurj]
 
 
 4.2.1 (2024-10-08)

--- a/src/collective/easyform/browser/view.py
+++ b/src/collective/easyform/browser/view.py
@@ -105,6 +105,10 @@ class EasyFormForm(AutoExtensibleForm, form.Form):
         return self.context.form_tabbing
 
     @property
+    def enable_autofocus(self):
+        return self.context.autofocus
+
+    @property
     def enable_unload_protection(self):
         return self.context.unload_protection
 

--- a/src/collective/easyform/interfaces/easyform.py
+++ b/src/collective/easyform/interfaces/easyform.py
@@ -200,6 +200,7 @@ class IEasyForm(Schema):
             "useCancelButton",
             "resetLabel",
             "form_tabbing",
+            "autofocus",
             "nameAttribute",
             "default_fieldset_label",
             "method",
@@ -239,6 +240,13 @@ class IEasyForm(Schema):
     form_tabbing = zope.schema.Bool(
         title=_(u"label_form_tabbing", default=u"Turn fieldsets to tabs"),
         description=_(u"help_form_tabbing", default=u""),
+        default=True,
+        required=False,
+    )
+    directives.write_permission(autofocus=config.EDIT_ADVANCED_PERMISSION)
+    autofocus = zope.schema.Bool(
+        title=_(u"label_autofocus", default=u"Enable focus on the first input"),
+        description=_(u"help_autofocus", default=u""),
         default=True,
         required=False,
     )

--- a/src/collective/easyform/locales/collective.easyform.pot
+++ b/src/collective/easyform/locales/collective.easyform.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,1008 +17,1017 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.easyform\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr ""
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr ""
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr ""
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr ""
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr ""
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr ""
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr ""
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr ""
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr ""
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr ""
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr ""
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr ""
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr ""
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr ""
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr ""
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr ""
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr ""
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr ""
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr ""
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr ""
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr ""
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr ""
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr ""
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr ""
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr ""
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr ""
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr ""
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr ""
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr ""
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr ""
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr ""
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr ""
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr ""
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr ""
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr ""
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr ""
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr ""
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr ""
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr ""
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr ""
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/collective.easyform.pot
+++ b/src/collective/easyform/locales/collective.easyform.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,1017 +17,1017 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.easyform\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr ""
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr ""
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr ""
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr ""
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr ""
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr ""
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr ""
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr ""
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr ""
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr ""
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr ""
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr ""
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr ""
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr ""
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr ""
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr ""
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr ""
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr ""
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr ""
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr ""
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr ""
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr ""
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr ""
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr ""
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr ""
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr ""
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr ""
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr ""
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr ""
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr ""
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr ""
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr ""
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr ""
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr ""
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr ""
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr ""
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr ""
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr ""
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr ""
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr ""
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr ""
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr ""
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr ""
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr ""
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr ""
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr ""
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr ""
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr ""
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr ""
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr ""
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr ""
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr ""
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr ""
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr ""
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr ""
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr ""
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr ""
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr ""
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr ""
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr ""
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2017-01-20 09:48+0000\n"
 "Last-Translator: Johannes Raggam <raggam-nl@adm.at>\n"
 "Language-Team: \n"
@@ -16,1017 +16,1017 @@ msgstr ""
 "Language: de\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} Eingabe(n) gespeichert."
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Art der Aktion"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Aktionsmodell"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Eine neue Aktion hinzufügen"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Adressierung"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Erlaubte Felder"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "CSV Trennzeichen"
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "Das CSV Trennzeichen muss angegeben werden."
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Wählen Sie einen Adapter aus."
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Alles löschen"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Formular Aktionen bearbeiten"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Formular Felder bearbeiten"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Aktion '${fieldname}' bearbeiten"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "XML Aktionsmodell bearbeiten"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "XML Feldmodell bearbeiten"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Exportieren"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Feldmodell"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formular importiert."
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Kopfzeilen"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Importieren"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Links sind nicht erlaubt."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Liste der Datenspeicher Adapter"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Muss eine gültige Liste von E-Mail Adressen sein (getrennt durch Kommas)."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Erforderliche Eingabe fehlt."
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Darf nicht angewählt sein."
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Keine Adapter verfügbar."
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Anpassungen"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Datum/Zeit des Eintrags"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Weiterleiten nach"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "HTML Bezeichnung"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Gespeicherte Daten"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Danke-Seite"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Diese Felder stehen für das Formular zur Verfügung."
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traversieren nach"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Überprüfungen"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Zurücksetzen"
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Absenden"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Danke für Ihren Beitrag."
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Vielen Dank"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Das Feld im Request an den Server übermitteln. Es ist im Formular nicht editierbar und wird auch dort nicht angezeigt."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} Kopfzeile"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Dieses Feld erlaubt die Veränderung der 'Standard' Fieldset Bezeichnung."
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Dieser Text wird nach den Formular Feldern angezeigt."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Zusätzliche E-Mail-Kopfzeilen. Kopfzeilen nur gemäss RFC822 setzen."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "E-Mail Adressen, die eine BCC (Blindkopie) erhalten sollen."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Text der als Fusszeilen am Ende der E-Mail durch zwei Minuszeichen abgetrennt angehängt wird."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Text, der in der E-Mail nach der Feldliste angezeigt wird."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Text, der in der E-Mail vor der Feldliste angezeigt wird."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "E-Mail Adressen, die eine CC (Kopie) erhalten sollen."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Empfänger E-Mail Adresse"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Vor- und Nachname des Empfängers"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Betreff Zeile der Nachricht. Diese wird verwendet, falls kein 'subject' Feld definiert wird oder dieses Feld leer ist."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Dieser Text wird über dem Formular angezeigt."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Wählen Sie mögliche zusätzliche Daten, die mit Ihrem Formular gespeichert werden sollen."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Wählen Sie welche Eingaben hier gespeichert werden sollen. Wenn leer, dann werden alle Eingaben gespeichert."
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Schreiben Sie ihr Script hier."
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rolle, unter der das Script ausgeführt werden soll."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Auswählen um eine CSV Datei mit den erhaltenen Eingaben als Anhang mit zu schicken."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr "Auswählen um eine XLSX Datei mit den erhaltenen Eingaben als Anhang mit zu schicken."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Auswählen um eine XML Datei mit den erhaltenen Eingaben als Anhang mit zu schicken."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Auswählen um alle Felder anzeigen zu lassen (außer Feld-Bezeichnung und Datei-Feldern). Wenn Sie dies auswählen, dann werden die Eingaben im Auswahlfeld unten ignoriert."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Wähle die Feldnamen, deren Eingaben in der Danke-Seite angezeigt werden sollen."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Wird in der Danke-Seite verwendet."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Dieser Text wird in der Danke-Seite nach den Feldern angezeigt."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Dieser Text wird in der Danke-Seite vor den Feldern angezeigt."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Sollen die Spaltenbezeichnungen als erste Zeile in der heruntergeladenen Eingabe erscheinen?"
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Wähle die Validatoren für diese Feld aus."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Wähle irgendwelche HTTP-Header, die in die E-Mail als 'X-' Kopfzeilen eingefügr werden sollen.' "
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "Importieren"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script nach der Validierung"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script zum Formular Setup"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCC Ausdruck"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CC Ausdruck"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "CSRF Schutz"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "Angepasstes Script"
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Eigene 'Standard' Fieldset Bezeichnung"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Download Format"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epilog des Formulars"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Ausfúhrungs Bedingung"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Feld Widget"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Erzwinge SSL Verbindung"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Verwandeln von Fieldsets in Reiter"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Eigene Formular Aktion"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Zusätzliche Kopfzeilen"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC Empfänger"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "E-Mail-Text (Signatur)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "E-Mail-Text (nach gestellt)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "E-Mail-Text (voran gestellt)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "E-Mail-Text Template"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "E-Mail Format"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC Empfänger"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Empfänger E-Mail Adresse"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Empfänger Vor- und Nachname"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "entnehme Reply-To aus"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Betreff"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "entnehme Betreff aus"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "entnehme Empfänger E-Mail aus"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Zusätzliche Tags in HTML-Head einfügen"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Versteckt"
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Leere Felder einbinden"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "Bezeichnung"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Leere Felder einbinden"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Alle Felder einbinden"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Zeige Antworten"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Formular Methode"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Formular Prolog"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Empfänger Ausdruck"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Beschriftung Zurücksetzen Knopf"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Beschriftung HTML"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "Datenspeicher"
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Extra Daten"
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Gespeicherte Felder"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script E-Mail Text"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy Rolle"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Sende CSV Daten als Anhang"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr "Sende XLSX Daten als Anhang"
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Sende XML Daten als Anhang"
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Ausdruck Absender"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Server-seitige Variable"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Zeige alle Felder"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Zeige Reset Knopf"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Zeige Antworten"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Ausdruck Betreff"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Beschriftung Absenden Knopf"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Eigener Absenden Knopf"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Ausdruck für 'Standard'"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Ausdrücke einschalten"
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Danke-Seite Zusammenfassung"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Danke-Seite Epilog"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Eigene Erfolgsaktion"
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Art der eigenen Erfolgsaktion "
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Danke-Seite Prolog"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Title der Danke-Seite"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Eigene Validierung"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Seite-Verlassen Schutz"
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Spaltennamen inkludieren"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Headers"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Der Filetype ${ftype} ist als Upload nicht erlaubt!"
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Die hochgeladene Datei ist grösser als ${size} Bytes!"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Komma getrennte Werte (CSV)"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Datum und Zeit an dem das Formular abgeschickt wurde"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Werte durch Tabulatoren getrennt (TSV)"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2017-01-20 09:48+0000\n"
 "Last-Translator: Johannes Raggam <raggam-nl@adm.at>\n"
 "Language-Team: \n"
@@ -16,1008 +16,1017 @@ msgstr ""
 "Language: de\n"
 "X-Generator: Poedit 1.8.11\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} Eingabe(n) gespeichert."
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Art der Aktion"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Aktionsmodell"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Eine neue Aktion hinzufügen"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Adressierung"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Erlaubte Felder"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "CSV Trennzeichen"
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "Das CSV Trennzeichen muss angegeben werden."
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Wählen Sie einen Adapter aus."
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Alles löschen"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Formular Aktionen bearbeiten"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Formular Felder bearbeiten"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Aktion '${fieldname}' bearbeiten"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "XML Aktionsmodell bearbeiten"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "XML Feldmodell bearbeiten"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Exportieren"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Feldmodell"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formular importiert."
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Kopfzeilen"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Importieren"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Links sind nicht erlaubt."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Liste der Datenspeicher Adapter"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Muss eine gültige Liste von E-Mail Adressen sein (getrennt durch Kommas)."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Erforderliche Eingabe fehlt."
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Darf nicht angewählt sein."
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Keine Adapter verfügbar."
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Anpassungen"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Datum/Zeit des Eintrags"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Weiterleiten nach"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Zurücksetzen"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "HTML Bezeichnung"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Gespeicherte Daten"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Danke-Seite"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Diese Felder stehen für das Formular zur Verfügung."
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traversieren nach"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Überprüfungen"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Zurücksetzen"
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Absenden"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Danke für Ihren Beitrag."
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Vielen Dank"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Das Feld im Request an den Server übermitteln. Es ist im Formular nicht editierbar und wird auch dort nicht angezeigt."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} Kopfzeile"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Dieses Feld erlaubt die Veränderung der 'Standard' Fieldset Bezeichnung."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Dieser Text wird nach den Formular Feldern angezeigt."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Zusätzliche E-Mail-Kopfzeilen. Kopfzeilen nur gemäss RFC822 setzen."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "E-Mail Adressen, die eine BCC (Blindkopie) erhalten sollen."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Text der als Fusszeilen am Ende der E-Mail durch zwei Minuszeichen abgetrennt angehängt wird."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Text, der in der E-Mail nach der Feldliste angezeigt wird."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Text, der in der E-Mail vor der Feldliste angezeigt wird."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "E-Mail Adressen, die eine CC (Kopie) erhalten sollen."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Empfänger E-Mail Adresse"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Vor- und Nachname des Empfängers"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Betreff Zeile der Nachricht. Diese wird verwendet, falls kein 'subject' Feld definiert wird oder dieses Feld leer ist."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Dieser Text wird über dem Formular angezeigt."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Wählen Sie mögliche zusätzliche Daten, die mit Ihrem Formular gespeichert werden sollen."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Wählen Sie welche Eingaben hier gespeichert werden sollen. Wenn leer, dann werden alle Eingaben gespeichert."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Schreiben Sie ihr Script hier."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rolle, unter der das Script ausgeführt werden soll."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Auswählen um eine CSV Datei mit den erhaltenen Eingaben als Anhang mit zu schicken."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr "Auswählen um eine XLSX Datei mit den erhaltenen Eingaben als Anhang mit zu schicken."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Auswählen um eine XML Datei mit den erhaltenen Eingaben als Anhang mit zu schicken."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Auswählen um alle Felder anzeigen zu lassen (außer Feld-Bezeichnung und Datei-Feldern). Wenn Sie dies auswählen, dann werden die Eingaben im Auswahlfeld unten ignoriert."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Wähle die Feldnamen, deren Eingaben in der Danke-Seite angezeigt werden sollen."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Wird in der Danke-Seite verwendet."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Dieser Text wird in der Danke-Seite nach den Feldern angezeigt."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Dieser Text wird in der Danke-Seite vor den Feldern angezeigt."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Sollen die Spaltenbezeichnungen als erste Zeile in der heruntergeladenen Eingabe erscheinen?"
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Wähle die Validatoren für diese Feld aus."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Wähle irgendwelche HTTP-Header, die in die E-Mail als 'X-' Kopfzeilen eingefügr werden sollen.' "
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "Importieren"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script nach der Validierung"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script zum Formular Setup"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCC Ausdruck"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CC Ausdruck"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "CSRF Schutz"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "Angepasstes Script"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Eigene 'Standard' Fieldset Bezeichnung"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Download Format"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epilog des Formulars"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Ausfúhrungs Bedingung"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Feld Widget"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Erzwinge SSL Verbindung"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Verwandeln von Fieldsets in Reiter"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Eigene Formular Aktion"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Zusätzliche Kopfzeilen"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC Empfänger"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "E-Mail-Text (Signatur)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "E-Mail-Text (nach gestellt)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "E-Mail-Text (voran gestellt)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "E-Mail-Text Template"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "E-Mail Format"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC Empfänger"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Empfänger E-Mail Adresse"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Empfänger Vor- und Nachname"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "entnehme Reply-To aus"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Betreff"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "entnehme Betreff aus"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "entnehme Empfänger E-Mail aus"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Zusätzliche Tags in HTML-Head einfügen"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Versteckt"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Leere Felder einbinden"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "Bezeichnung"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Leere Felder einbinden"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Alle Felder einbinden"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Zeige Antworten"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Formular Methode"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Formular Prolog"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Empfänger Ausdruck"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Beschriftung Zurücksetzen Knopf"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Beschriftung HTML"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "Datenspeicher"
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Extra Daten"
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Gespeicherte Felder"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script E-Mail Text"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy Rolle"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Sende CSV Daten als Anhang"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr "Sende XLSX Daten als Anhang"
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Sende XML Daten als Anhang"
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Ausdruck Absender"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Server-seitige Variable"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Zeige alle Felder"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Zeige Reset Knopf"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Zeige Antworten"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Ausdruck Betreff"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Beschriftung Absenden Knopf"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Eigener Absenden Knopf"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Ausdruck für 'Standard'"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Ausdrücke einschalten"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Danke-Seite Zusammenfassung"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Danke-Seite Epilog"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Eigene Erfolgsaktion"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Art der eigenen Erfolgsaktion "
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Danke-Seite Prolog"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Title der Danke-Seite"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Eigene Validierung"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Seite-Verlassen Schutz"
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Spaltennamen inkludieren"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Headers"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Der Filetype ${ftype} ist als Upload nicht erlaubt!"
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Die hochgeladene Datei ist grösser als ${size} Bytes!"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Komma getrennte Werte (CSV)"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Datum und Zeit an dem das Formular abgeschickt wurde"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Werte durch Tabulatoren getrennt (TSV)"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,1017 +14,1017 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr ""
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr ""
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr ""
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr ""
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr ""
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr ""
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr ""
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr ""
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr ""
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr ""
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr ""
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr ""
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr ""
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr ""
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr ""
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr ""
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr ""
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr ""
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr ""
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr ""
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr ""
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr ""
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr ""
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr ""
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr "Enable autofocus on the first input"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr ""
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr ""
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr ""
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr ""
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr ""
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr ""
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr "Autofocus"
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr ""
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr ""
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr ""
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr ""
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr ""
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr ""
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr ""
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr ""
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr ""
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr ""
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr ""
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr ""
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr ""
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr ""
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr ""
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr ""
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr ""
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr ""
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr ""
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr ""
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr ""
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr ""
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr ""
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr ""
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr ""
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr ""
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr ""
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr ""
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr ""
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr ""
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,1008 +14,1017 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr ""
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr ""
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr ""
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr ""
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr ""
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr "Enable autofocus on the first input"
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr ""
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr ""
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr ""
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr ""
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr ""
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr ""
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr ""
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr ""
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr ""
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr ""
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr "Autofocus"
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr ""
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr ""
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr ""
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr ""
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr ""
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr ""
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr ""
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr ""
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr ""
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr ""
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr ""
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr ""
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr ""
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr ""
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr ""
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr ""
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr ""
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr ""
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr ""
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr ""
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr ""
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr ""
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr ""
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr ""
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr ""
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr ""
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr ""
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr ""
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr ""
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr ""
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr ""
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr ""
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr ""
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr ""
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr ""
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr ""
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr ""
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr ""
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr ""
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr ""
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr ""
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr ""
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2023-02-13 03:30-0400\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -20,1009 +20,1018 @@ msgstr ""
 "Language: es\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} entrada(s) guardada(s)"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr "Un constructor de formularios web"
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Tipo de Acción"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modelo de Acción"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Añadir nueva acción"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Direcciónes"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Campos permitidos"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "delimitador CSV"
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "El delimitador CSV es obligatorio."
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Elige un adaptador."
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Limpiar"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr "Comentarios"
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Configurar acciones"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Configurar campos"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr "Entrada de formulario de correos electrónicos"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar acción '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Editar XML de Modelo de Acción"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Editar XML de Modelo de Campos"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr "Ingrese las opciones permitidas una por línea."
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr "Error: todos los elementos del modelo deben ser 'schema'"
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr "Error: la etiqueta raíz debe ser 'model'"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Exportar"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modelo de campos"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr "Envío de formulario"
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulario importado."
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Cabeceras"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Importar"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "No se permiten enlaces."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Lista de adaptadores de Guardar datos"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr "Remitente"
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Tiene que ser una lista de dirección de correo electrónico válidas (separada por comas)."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Tiene que estar seleccionado."
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "No tiene que estar seleccionado."
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "No hay adaptadores disponibles."
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Personalización"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr "Respuestas posibles"
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr "Posibles preguntas"
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Día y hora del envío"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Redirigir a"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Limpiar"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etiqueta de texto enriquecido"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr "Datos guardados"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Datos almacenados"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Establezca el delimitador predeterminado para la descarga de CSV."
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr "Asunto"
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Página de agradecimiento"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Estos campos están disponibles para tus formularios."
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Ir a"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validadores"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr "Vista"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Su dirección de correo electrónico"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Limpiar"
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Enviar"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Gracias por su envío"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Gracias"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Activar este campo para que su valor se inyecte automáticamente en la petición, se pueda utilizar por alguna acción, no sea expuesto al cliente y éste no lo pueda modificar."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr "Ajustes de easyform"
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "Cabecera ${name}"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Una expresión TALES que será llamada después que el formulario se valide, pero antes de llamar un adaptador de acción (si hay alguno) o mostrar la página de agradecimiento. Los datos introducidos en el formulario estará en el diccionario \\\"request.form\\\". Déjela vacía si no la necesita. El uso más común de este campo es para llamar un script python para limpiar la entrada del formulario o para ejecutar una acción alternativa. Cualquier valor devuelto por la expresión se ignorará. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Una expresión TALES que será llamada cuando el formulario se muestra. Déjela vacía si no la necesita. El uso más común de este campo es para llamar un script python que asigna valores por defecto para múltiples campos pre-populando el request.form. Cualquier valor devuelto por la expresión se ignorará. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Una expresión TALES que devolverá el listado de correos electrónicos que sobreescribirán el valor del campo BCC. Ten cuidado al utilizar datos del request sin validar para esto. Déjela vacía si no la necesita. La expresión deberá devolver una lista de cadenas de texto. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Una expresión TALES que devolverá el listado de correos electrónicos que sobreescribirán el valor del campo CC. Ten cuidado al utilizar datos del request sin validar para esto. Déjela vacía si no la necesita. La expresión deberá devolver una lista de cadenas de texto. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Activar para utilizar la protección Cross-Site Request Forgery. Solo se permitirán peticiones HTTP POST."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Con este campo puedes modificar la etiqueta del conjunto de campos por defecto."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Este texto se mostrará después de los campos del formulario."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Una expresión TALES que será evaluada para decidir si se ejecutará esta acción o no. Déjela vacía si no la necesita. La expresión deberá devolver un valor booleano; return True para que la acción se ejecute. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Activar para que el formulario se muestre en la versión con SSL activado (https://) si se accede a él desde una versión no-SSL (http://). Para que esta redirección funcione adecuadamente, el servidor web tiene que estar configurado para servir peticiones con el protocolo HTTPS en el puerto 443 y redirigir las peticiones a Zope."
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Utiliza este campo para sobreescribir el valor del atributo \"action\" del formulario. Especifica la URL a la que se enviarán los datos. Esta configuración hará que no se ejecute la validación, las acciones configuradas y la página de agradecimiento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Cabeceras adicionales del correo electrónico enviado. Utilizar solo cabeceras RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Correos electrónicos que recibirán una copia oculta (BCC, CCO)"
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Texto que se añade en el pie de página."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Texto que se añade después los campos del cuerpo de texto"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Texto que se añade antes de los campos del cuerpo de texto"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Esta es una plantilla Zope Page Templates que se utiliza para crear el texto del correo electrónico. No necesitas modificarla, pero si sabes TAL puedes personalizar los mensajes."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Establece el tipo MIME del cuerpo del mensaje. Cambiar solo si se sabe que está haciendo. Déjalo vacío para el comportamiento habitual."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Correos electrónicos que recibirán una copia del mensaje (CC)."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Correo electrónico del receptor"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Nombre del receptor"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor de la cabecera \"Reply-To\". NOTA: Deberías activar la validación para verificar que el campo contenga una dirección de correo electrónico."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Asunto del mensaje. Se utiliza si no eliges un campo para extraer el asunto o si el valor de dicho campo es vacío."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor del asunto del mensaje."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor de la cabecera \\\"To\\\", es decir, a quién se enviará el formulario. Si seleccionas algo que no sea \\\"None\\\", esto sobreescribirá el valor del correo electrónico del \\\"Receptor\\\". Cuidado al utilizar valores introducidos por el usuario que no se hayan validado o limpiado."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Este campo permite introducir código en la cabecera HTML. El uso más habitual es para introducir CSS o JavaScript. Especificar una expresión TALES que devuelva una cadena de caracteres. La cadena se incorporará tal cual al HTML. TENGA EN CUENTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "El campo está oculto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Seleccionar para mostrar los títulos de los campos que se han dejado vacíos. Si no está seleccionado, los campos vacíos no se mostrarán en el listado."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Seleccionar para mostrar los títulos de los campos que se han dejado vacíos en el mensaje. Si no está seleccionado, los campos vacíos no se mostrarán en el mensaje."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Seleccionar para incluir todos los campos (excepto los campos de etiqueta y los de archivo). Si está seleccionado, la selección del campo siguiente se ignorará."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Elija los campos cuyas entradas le gustaría incluir en el correo electrónico."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr "opcional, establece el atributo de nombre en el contenedor del formulario. se puede usar para análisis de formularios"
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Este texto se mostrará antes que los campos del formulario"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor del campo del correo electrónico del receptor del mensaje. Cuidado al utilizar datos no validados del formulario. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. TENGA EN CUENTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Seleccionar los datos adicionales a guardar junto con los datos del formulario."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Elija los campos cuyas entradas le gustaría incluir en los datos guardados. Si está vacío, se guardarán todos los campos."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Escribir el script aquí."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rol con el que se ejecutará el script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Marque esto para enviar un archivo CSV adjunto que contenga los valores completados en el formulario."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr "Marque esto para incluir el encabezado CSV/XLSX en los archivos adjuntos."
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr "Marque esto para enviar un archivo XLSX adjunto que contenga los valores completados en el formulario."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Marque esto para enviar un archivo XML adjunto que contenga los valores completados en el formulario."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Una expresión TALES que se evaluará para anular el encabezado \\\"From\\\". Dejar vacío si no es necesario. Su expresión debe evaluarse como una cadena. TENGA EN CUENTA: los errores en la evaluación de esta expresión provocarán un error en la visualización del formulario."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Seleccionar para mostrar los datos de todos los campos (salvo los campos de etiqueta y de archivo). Si está seleccionado, la selección del campo siguiente se ignorará."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Seleccionar los campos que se mostrarán en la página de agradecimiento."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor del campo asunto. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Este campo permite sobreescribir el texto del botón de envío del formulario. El uso más habitual es cambiar la etiqueta según algún parámetro de la petición. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Una expresión TALES que se evaluará cuando se muestre el formulario para obtener el valor por defecto del campo. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Una expresión TALES que se evaluará para decidir si el campo está activo o no. La expresión deberá evaluarse como True si el campo se tiene que incluir en el formulario y False si no debe ser incluido. Déjela vacía si no la necesita y en ese caso el campo se incluirá. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Usado en la página de agradecimiento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "El texto se mostrará tras los datos del formulario."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Este campo se utiliza en lugar de la página de agradecimiento para determinar a dónde redirigir al usuario después de la acción (si hay alguna). Normalmente se utilizará para una plantilla o script personalizado. Déjela vacía si no la necesita. El valor debe ser una acción de CMFFormController y el argumento (por ejemplo: \\\"redirect_to\\\" ó \\\"traverse_to\\\" y la expresión TALES correspondiente. Por ejemplo, \\\"Redirect to\\\" y \\\"string:thanks-page\\\" podria redirigiría a \\\"thanks-page\\\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Este campo se utiliza en lugar de la página de agradecimiento para determinar a dónde redirigir al usuario después de la acción (si hay alguna). Normalmente se utilizará para una plantilla o script personalizado. Déjela vacía si no la necesita. El valor debe ser una acción de CMFFormController y el argumento, completo con el tipo de acción a ejecutar (por ejemplo, \\\"redirect_to\\\" o \\\"traverse_to\\\") y una expresión TALES. Por ejemplo, \\\"Redirigir a\\\" y \\\"string:thanks-page\\\" redirigirían a \\\"thanks-page\\\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Este texto se mostrará antes de los datos del formulario."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Una expresión TALES que se evaluará al validar el formulario. Utilizar 'value' para realizar la validación, que contendrá el dato introducir. Devolver False si es válido; si no devolver el mensaje de error. Por ejemplo: \\\"python:test(value=='casa', False, 'tiene que introducir casa')\\\" requerirá que el valor introducio sea \\\"casa\\\". NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "¿Añadir los nombres de los campos como primera línea del archivo descargado?"
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Seleccionar los validadores de este campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Seleccionar cualquier elemento de las cabeceras HTTP que se quiera introducir como cabecera X-header del mensaje."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "Importar"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script post-validación"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de preparación del formulario"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Expresión CCO/BCC"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Expressión CC"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Protección CSRF"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personalizado"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Etiqueta personalizada del conjunto de campos por defecto"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Formato de la descarga"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epílogo del formulario"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condición de ejecución"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Widget del campo"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forzar conexión SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Convertir conjuntos de campos a pestañas"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Acción personalizada"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Cabeceras adicionales"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Receptores CCO/BCC"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Cuerpo (firma)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Cuerpo (añadido después)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Cuerpo (añadido antes)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Plantilla del mensaje"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Formato del mensaje"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Receptores CC"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Correo electrónico del receptor"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nombre del receptor"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Extraer Reply-To"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Asunto"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Extraer Asunto"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Extraer Receptor"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr "HCaptcha"
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Inyección de cabeceras"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Oculto"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Incluir valores vacíos"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "Etiqueta"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr "Me gusta"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Incluir vacíos"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Incluir todos los campos"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr "Remitente"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Mostrar respuestas"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Método del formulario"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr "Atributo de nombre"
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr "NorobotCaptcha"
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prólogo del formulario"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Expresión del receptor"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Etiqueta del botón reset"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Etiqueta de texto enriquecido"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "Guardar datos"
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Datos adicionales"
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Campos guardados"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Cuerpo del script"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy rol"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Enviar archivo adjunto de datos CSV"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr "Incluir encabezado en los datos CSV/XLSX adjuntos"
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr "Enviar archivo adjunto de datos XLSX"
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Enviar archivo adjunto de datos XML"
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Expresión del remitente"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variable del Servidor"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Mostrar todos los campos"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Mostrar botón reset"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Mostrar respuestas"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Expresión de Asunto"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Etiqueta del botón Enviar"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Etiqueta del botón Enviar personalizada"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Expresión por defecto"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Expresión habilitante"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Descripción del agradecimiento"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epílogo del agradecimiento"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Acción personalizada"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Tipo de acción personalizada"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prólogo del agradecimiento"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Título del agradecimiento"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validador personalizado"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Protección de descarga"
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Incluir nombres de columnas"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "Cabeceras HTTP"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Archivo no permitido"
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Archivo demasiado grande"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr "Los datos guardados de ${formname} almacenados en el adaptador ${adapter}"
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Archivo CSV (separado por comas)"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Día/Hora del envío"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Archivo TSV (separado por tabulaciones)"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr "XLSX"

--- a/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2023-02-13 03:30-0400\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -20,1018 +20,1018 @@ msgstr ""
 "Language: es\n"
 "X-Generator: Virtaal 0.7.1\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} entrada(s) guardada(s)"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr "Un constructor de formularios web"
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Tipo de Acción"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modelo de Acción"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Añadir nueva acción"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Direcciónes"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Campos permitidos"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "delimitador CSV"
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "El delimitador CSV es obligatorio."
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Elige un adaptador."
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Limpiar"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr "Comentarios"
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Configurar acciones"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Configurar campos"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr "Entrada de formulario de correos electrónicos"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar acción '${fieldname}'"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Editar XML de Modelo de Acción"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Editar XML de Modelo de Campos"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr "Ingrese las opciones permitidas una por línea."
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr "Error: todos los elementos del modelo deben ser 'schema'"
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr "Error: la etiqueta raíz debe ser 'model'"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Exportar"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modelo de campos"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr "Envío de formulario"
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulario importado."
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Cabeceras"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Importar"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "No se permiten enlaces."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Lista de adaptadores de Guardar datos"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr "Remitente"
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Tiene que ser una lista de dirección de correo electrónico válidas (separada por comas)."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Tiene que estar seleccionado."
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "No tiene que estar seleccionado."
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "No hay adaptadores disponibles."
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Personalización"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr "Respuestas posibles"
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr "Posibles preguntas"
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Día y hora del envío"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Redirigir a"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Limpiar"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etiqueta de texto enriquecido"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr "Datos guardados"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Datos almacenados"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Establezca el delimitador predeterminado para la descarga de CSV."
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr "Asunto"
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Página de agradecimiento"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Estos campos están disponibles para tus formularios."
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Ir a"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validadores"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr "Vista"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Su dirección de correo electrónico"
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Limpiar"
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Enviar"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Gracias por su envío"
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Gracias"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Activar este campo para que su valor se inyecte automáticamente en la petición, se pueda utilizar por alguna acción, no sea expuesto al cliente y éste no lo pueda modificar."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr "Ajustes de easyform"
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "Cabecera ${name}"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Una expresión TALES que será llamada después que el formulario se valide, pero antes de llamar un adaptador de acción (si hay alguno) o mostrar la página de agradecimiento. Los datos introducidos en el formulario estará en el diccionario \\\"request.form\\\". Déjela vacía si no la necesita. El uso más común de este campo es para llamar un script python para limpiar la entrada del formulario o para ejecutar una acción alternativa. Cualquier valor devuelto por la expresión se ignorará. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Una expresión TALES que será llamada cuando el formulario se muestra. Déjela vacía si no la necesita. El uso más común de este campo es para llamar un script python que asigna valores por defecto para múltiples campos pre-populando el request.form. Cualquier valor devuelto por la expresión se ignorará. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Una expresión TALES que devolverá el listado de correos electrónicos que sobreescribirán el valor del campo BCC. Ten cuidado al utilizar datos del request sin validar para esto. Déjela vacía si no la necesita. La expresión deberá devolver una lista de cadenas de texto. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Una expresión TALES que devolverá el listado de correos electrónicos que sobreescribirán el valor del campo CC. Ten cuidado al utilizar datos del request sin validar para esto. Déjela vacía si no la necesita. La expresión deberá devolver una lista de cadenas de texto. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Activar para utilizar la protección Cross-Site Request Forgery. Solo se permitirán peticiones HTTP POST."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Con este campo puedes modificar la etiqueta del conjunto de campos por defecto."
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Este texto se mostrará después de los campos del formulario."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Una expresión TALES que será evaluada para decidir si se ejecutará esta acción o no. Déjela vacía si no la necesita. La expresión deberá devolver un valor booleano; return True para que la acción se ejecute. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Activar para que el formulario se muestre en la versión con SSL activado (https://) si se accede a él desde una versión no-SSL (http://). Para que esta redirección funcione adecuadamente, el servidor web tiene que estar configurado para servir peticiones con el protocolo HTTPS en el puerto 443 y redirigir las peticiones a Zope."
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Utiliza este campo para sobreescribir el valor del atributo \"action\" del formulario. Especifica la URL a la que se enviarán los datos. Esta configuración hará que no se ejecute la validación, las acciones configuradas y la página de agradecimiento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Cabeceras adicionales del correo electrónico enviado. Utilizar solo cabeceras RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Correos electrónicos que recibirán una copia oculta (BCC, CCO)"
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Texto que se añade en el pie de página."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Texto que se añade después los campos del cuerpo de texto"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Texto que se añade antes de los campos del cuerpo de texto"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Esta es una plantilla Zope Page Templates que se utiliza para crear el texto del correo electrónico. No necesitas modificarla, pero si sabes TAL puedes personalizar los mensajes."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Establece el tipo MIME del cuerpo del mensaje. Cambiar solo si se sabe que está haciendo. Déjalo vacío para el comportamiento habitual."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Correos electrónicos que recibirán una copia del mensaje (CC)."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Correo electrónico del receptor"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Nombre del receptor"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor de la cabecera \"Reply-To\". NOTA: Deberías activar la validación para verificar que el campo contenga una dirección de correo electrónico."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Asunto del mensaje. Se utiliza si no eliges un campo para extraer el asunto o si el valor de dicho campo es vacío."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor del asunto del mensaje."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Elige un campo del formulario del que se extraerá el valor de la cabecera \\\"To\\\", es decir, a quién se enviará el formulario. Si seleccionas algo que no sea \\\"None\\\", esto sobreescribirá el valor del correo electrónico del \\\"Receptor\\\". Cuidado al utilizar valores introducidos por el usuario que no se hayan validado o limpiado."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Este campo permite introducir código en la cabecera HTML. El uso más habitual es para introducir CSS o JavaScript. Especificar una expresión TALES que devuelva una cadena de caracteres. La cadena se incorporará tal cual al HTML. TENGA EN CUENTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "El campo está oculto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Seleccionar para mostrar los títulos de los campos que se han dejado vacíos. Si no está seleccionado, los campos vacíos no se mostrarán en el listado."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Seleccionar para mostrar los títulos de los campos que se han dejado vacíos en el mensaje. Si no está seleccionado, los campos vacíos no se mostrarán en el mensaje."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Seleccionar para incluir todos los campos (excepto los campos de etiqueta y los de archivo). Si está seleccionado, la selección del campo siguiente se ignorará."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Elija los campos cuyas entradas le gustaría incluir en el correo electrónico."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr "opcional, establece el atributo de nombre en el contenedor del formulario. se puede usar para análisis de formularios"
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Este texto se mostrará antes que los campos del formulario"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor del campo del correo electrónico del receptor del mensaje. Cuidado al utilizar datos no validados del formulario. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. TENGA EN CUENTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Seleccionar los datos adicionales a guardar junto con los datos del formulario."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Elija los campos cuyas entradas le gustaría incluir en los datos guardados. Si está vacío, se guardarán todos los campos."
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Escribir el script aquí."
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rol con el que se ejecutará el script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Marque esto para enviar un archivo CSV adjunto que contenga los valores completados en el formulario."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr "Marque esto para incluir el encabezado CSV/XLSX en los archivos adjuntos."
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr "Marque esto para enviar un archivo XLSX adjunto que contenga los valores completados en el formulario."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Marque esto para enviar un archivo XML adjunto que contenga los valores completados en el formulario."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Una expresión TALES que se evaluará para anular el encabezado \\\"From\\\". Dejar vacío si no es necesario. Su expresión debe evaluarse como una cadena. TENGA EN CUENTA: los errores en la evaluación de esta expresión provocarán un error en la visualización del formulario."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Seleccionar para mostrar los datos de todos los campos (salvo los campos de etiqueta y de archivo). Si está seleccionado, la selección del campo siguiente se ignorará."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Seleccionar los campos que se mostrarán en la página de agradecimiento."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Una expresión TALES que se evaluará para sobreescribir cualquier valor del campo asunto. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Este campo permite sobreescribir el texto del botón de envío del formulario. El uso más habitual es cambiar la etiqueta según algún parámetro de la petición. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Una expresión TALES que se evaluará cuando se muestre el formulario para obtener el valor por defecto del campo. Déjela vacía si no la necesita. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Una expresión TALES que se evaluará para decidir si el campo está activo o no. La expresión deberá evaluarse como True si el campo se tiene que incluir en el formulario y False si no debe ser incluido. Déjela vacía si no la necesita y en ese caso el campo se incluirá. La expresión debería devolver una cadena de caracteres. NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Usado en la página de agradecimiento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "El texto se mostrará tras los datos del formulario."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Este campo se utiliza en lugar de la página de agradecimiento para determinar a dónde redirigir al usuario después de la acción (si hay alguna). Normalmente se utilizará para una plantilla o script personalizado. Déjela vacía si no la necesita. El valor debe ser una acción de CMFFormController y el argumento (por ejemplo: \\\"redirect_to\\\" ó \\\"traverse_to\\\" y la expresión TALES correspondiente. Por ejemplo, \\\"Redirect to\\\" y \\\"string:thanks-page\\\" podria redirigiría a \\\"thanks-page\\\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Este campo se utiliza en lugar de la página de agradecimiento para determinar a dónde redirigir al usuario después de la acción (si hay alguna). Normalmente se utilizará para una plantilla o script personalizado. Déjela vacía si no la necesita. El valor debe ser una acción de CMFFormController y el argumento, completo con el tipo de acción a ejecutar (por ejemplo, \\\"redirect_to\\\" o \\\"traverse_to\\\") y una expresión TALES. Por ejemplo, \\\"Redirigir a\\\" y \\\"string:thanks-page\\\" redirigirían a \\\"thanks-page\\\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Este texto se mostrará antes de los datos del formulario."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Una expresión TALES que se evaluará al validar el formulario. Utilizar 'value' para realizar la validación, que contendrá el dato introducir. Devolver False si es válido; si no devolver el mensaje de error. Por ejemplo: \\\"python:test(value=='casa', False, 'tiene que introducir casa')\\\" requerirá que el valor introducio sea \\\"casa\\\". NOTA: errores en la evaluación de esta expresión causarán un error al mostrar el formulario."
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "¿Añadir los nombres de los campos como primera línea del archivo descargado?"
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Seleccionar los validadores de este campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Seleccionar cualquier elemento de las cabeceras HTTP que se quiera introducir como cabecera X-header del mensaje."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "Importar"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script post-validación"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de preparación del formulario"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Expresión CCO/BCC"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Expressión CC"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Protección CSRF"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personalizado"
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Etiqueta personalizada del conjunto de campos por defecto"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Formato de la descarga"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epílogo del formulario"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condición de ejecución"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Widget del campo"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forzar conexión SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Convertir conjuntos de campos a pestañas"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Acción personalizada"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Cabeceras adicionales"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Receptores CCO/BCC"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Cuerpo (firma)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Cuerpo (añadido después)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Cuerpo (añadido antes)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Plantilla del mensaje"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Formato del mensaje"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Receptores CC"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Correo electrónico del receptor"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nombre del receptor"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Extraer Reply-To"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Asunto"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Extraer Asunto"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Extraer Receptor"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr "HCaptcha"
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Inyección de cabeceras"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Oculto"
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Incluir valores vacíos"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "Etiqueta"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr "Me gusta"
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Incluir vacíos"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Incluir todos los campos"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr "Remitente"
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Mostrar respuestas"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Método del formulario"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr "Atributo de nombre"
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr "NorobotCaptcha"
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prólogo del formulario"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Expresión del receptor"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Etiqueta del botón reset"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Etiqueta de texto enriquecido"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "Guardar datos"
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Datos adicionales"
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Campos guardados"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Cuerpo del script"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy rol"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Enviar archivo adjunto de datos CSV"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr "Incluir encabezado en los datos CSV/XLSX adjuntos"
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr "Enviar archivo adjunto de datos XLSX"
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Enviar archivo adjunto de datos XML"
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Expresión del remitente"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variable del Servidor"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Mostrar todos los campos"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Mostrar botón reset"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Mostrar respuestas"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Expresión de Asunto"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Etiqueta del botón Enviar"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Etiqueta del botón Enviar personalizada"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Expresión por defecto"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Expresión habilitante"
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Descripción del agradecimiento"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epílogo del agradecimiento"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Acción personalizada"
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Tipo de acción personalizada"
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prólogo del agradecimiento"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Título del agradecimiento"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validador personalizado"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Protección de descarga"
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Incluir nombres de columnas"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "Cabeceras HTTP"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Archivo no permitido"
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Archivo demasiado grande"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr "Los datos guardados de ${formname} almacenados en el adaptador ${adapter}"
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Archivo CSV (separado por comas)"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Día/Hora del envío"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Archivo TSV (separado por tabulaciones)"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr "XLSX"

--- a/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2017-10-22 16:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,1019 +16,1019 @@ msgstr ""
 "Language: eu\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} elementu gorde dira"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Akzio mota"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Akzioen eredua"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Akzio berria gehitu"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Helbideak"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Onartutako eremuak"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Guztiak ezabatu"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Formularioaren akzioak konfiguratu"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Formularioaren eremuak konfiguratu"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "'${fieldname}' akzioa aldatu"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Akzioen XML eredua editatu"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Eremuen XML eredua editatu"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Esportatu"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Eremuen eredua"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulario ondo inportatu da."
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Goiburukoak"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Inportatu"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Ez dira loturak onartzen."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Eposta helbideen zerrenda bat izan behar da (komarekin banatuta)."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Aukeratuta egon behar da"
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Ezin da aukeratuta egon"
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Gainidazketak"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Bidalketaren data/ordua"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Berbideratu (redirect_to)"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Garbitu"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etiketa aberatsa"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Gordetako datuak"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Eskertza-orria"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Eremu hauek gehitu daitezke formularioetan."
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Joan (traverse_to)"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Balidadoreak"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Garbitu"
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Bidali"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Eskerrik asko bidalketagatik"
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Eskerrik asko"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Aktibatuz gero, eremu honen balioa akzioek erabiliko dute bakarrik eta ez da formularioan erakutsiko."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} goiburukoa"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Formularioa ondo balidatu ostean baina edozein akzio exekutatu edo eskertza orrialde erakutsi baino lehen exekutatuko den TALES espresioa. Formularioan sartutako datuak request.form-en egongo dira. Utzi hutsik ez baduzu behar. Eremu honen erabilpen arruntena, formularioko datuak garbitzeko edo akzio gisa erabiliko den python script bati deitzea da. Espresioak itzulitako edozein erantzun ez da kontuan hartuko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Formularioa erakustean exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Eremu honen erabilpen arruntena formularioaren eremuen defektuzko balioak ezarriko dituen python script bati deitzea da, horretarako request.form-en balioak ezarriko dituelarik. Espresioak itzulitako edozein erantzun ez da kontuan hartuko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "BCC zerrendaren balioak gainidatziko dituen TALES espresioa. Kontuz honetarako balioztatu gabeko edozein balio erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-kate zerrenda bat itzuli behar du. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "CC zerrendaren balioak gainidatziko dituen TALES espresioa. Kontuz honetarako balioztatu gabeko edozein balio erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-kate zerrenda bat itzuli behar du. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Aktibatuta badago CSRF edo Cross-Site-Request-Forgery deritzon babesa erabiltzen du. Izan kontuan kasu horretan HTTP POST erako akzioak bakarrik onartuko direla."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Eremu honek defektuzko eremu-multzoaren etiketa aldatzen uzten dizu."
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Formularioaren eremuen ostean agertuko den testua."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Akzio hau exekutatu ala ez erabakitzeko exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak balio boolear bat itzuli behar du; True itzuli akzioa exekutatzeko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr " "
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Aktibatuta badago, automatikoki HTTPS darabilen helbidera berbideratuko da formularioa (https://). Ondo funtzionatzeko aurrez web zerbitzaria konfiguratu behar duzu HTTPS protokoloarekin funtzionatu dezan eta eskaerak Plone zerbitzari bidera ditzan."
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr " "
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Formularioaren 'action' atributua gainidazteko erabili eremu hau. Idatzi hemen formularioaren datuak zein URLtara bidali behar diren. Hau erabiliz gero formularioaren balidazioa, eta konfiguratutako akzioak eta eskertza-orriak ez dira kontuan hartuko."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Eposta mezuan gehitu beharreko goiburu gehigarriak. RFC822rekin bat datozen goiburuak bakarrik erabili."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "BCC kopia ezkutu bat jasoko duten helbideak."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Mezuaren oinean gehituko den testua, mezuaren azpian agertuko da marradun lerro baten ostean."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Mezuaren gorputzean dauden eremuei ondoren gehituko zaien testua"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Mezuaren gorputzean dauden eremuei aurretik gehituko zaien testua"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Mezuaren gorputza sortzeko erabiliko den txantilioia (ZPT). Ez duzu zertan aldatu, baina TAL baldin badakizu, bidalitako mezuaren itxura osorik pertsonalizatu dezakezu."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Mezuaren mime-type-a zehaztu. Zer egiten ari zaren badakizu bakarrik aldatu. Utzi hutsik defektuzko portaerarako."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "CC kopia bat jasoko duten helbideak."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Jasotzailearen eposta helbidea"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Jasotzailearen izena"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Reply-To goiburukoaren balioa ateratzeko formularioko eremua aukeratu. OHARRA: aukeratu duzun eremuarentzat eposta balidatzailea aktibatzea gomendatzen dizugu"
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Mezuaren gaia. Hauxe erabiliko da ez baduzu gai eremua erabili edo eremua hutsik badago"
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Mezuaren gaia formularioko zein eremutatik atera aukeratu."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "To goiburuaren balioa (mezuaren jasotzailea) zein eremutatik atera aukeratu. \"None\" ez den beste zerbait aukeratzen baduzu, honek \"Jasotzaileak\" goiko ezarpena gainidatziko du. Kontuz ibili balidatu gabeko balioak onartzearekin."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "HTML goiburuan edukia txertatu dezakezu. Erabilpen arruntena CSS eta JavaScripta txertatzea izaten da. Idatzi testu-kate bat itzuliko duen TALES espresio bat. Testu katea interpretatu gabe txertatuko da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Aukeratuta badago baliorik jaso ez duten formularioko eremuen etiketak erakutsi egingo dira. "
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Aukeratuta badago baliorik jaso ez duten formularioko eremuen etiketak erakutsi egingo dira bidalitako epostan. "
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Aukeratuta badago eremu guztien balioak (etiketak eta fitxategiak izan ezik) sartuko dira eposta mezuan. Aukeratzen baduzu, beheko kutxako aukerak ez dira kontuan hartuko."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Aukeratu zein eremuren balioak bidali nahi dutuzun eposta mezuan."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr " "
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Formularioko eremuen aurretik agertuko den testua."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Jasotzailearen epostaren balioa gainidazteko exekutatuko den TALES espresioa. Kontuz ibili balidatu gabeko balioak erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-katea bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr " "
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Formularioaren datuekin batera gorde nahi duzun beste edozein balio gehigarri aukeratu."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Aukeratu zein balio gorde nahi dituzun. Hutsik uzten baduzu, eremu guztien balioak gordeko dira."
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Idatzi hemen zuren scripta"
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Scripta zein rolekin exekutatuko den."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "\"From\" (bidaltzailea) goiburukoaren balioa gainidazteko erabiliko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Aukeratuta badago eremu guztien balioak erakutsiko ditu (etiketak eta fitxategiak izan ezik). Aukeratzen baduzu, beheko kutxako aukerak ez dira kontuan hartuko."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr " "
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Aukeratu zein eremuren balioak erakutsi nahi dituzun eskertza-orrian."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Epostaren gaia gainidazteko exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr " "
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Bidalketa botoiaren etiketa aldatzeko TALES espresioa. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Eremuaren defektuzko balioa lortzeko formularioa erakustean exekutatuko den TALES espresioa. Utzi hutsik behar ez baduzu. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Eremua aktibo egongo den edo ez erabakitzeko formularioa erakustean exekutatuko den TALES espresioa. Espresioak True balio boolearra itzuli beharko du eremua formularioan erakustarazi nahi baduzu, aldiz, False ez bada erakutsi behar. Utzi hutsik behar ez baduzu: horrela eremua erakutsi egingo da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Eskertza-orrian erabiliko da."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Eremuen balioen ostean erakutsiko den testua."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Erabili eremu hau eskertza orriaren ordez, formularioaren akzioaren ondoren erakutsiko den helbidea zehazteko. Erabilpen arrunta arrakasta orrialde bat edo script bat exekutatzea da. Utzi hutsik behar ez baduzu. Bestela CMFFormController erako akzio gisa idatzi behar duzu. Adibidez: \"redirect_to\" edo \"traverse_to\" eta ondoren TALES espresio bat. Esaterako: \"redirect_to: string:thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Erabili eremu hau eskertza orriaren ordez, formularioaren akzioaren ondoren erakutsiko den helbidea zehazteko. Erabilpen arrunta arrakasta orrialde bat edo script bat exekutatzea da. Utzi hutsik behar ez baduzu. Bestela CMFFormController erako akzio gisa idatzi behar duzu. Adibidez: \"redirect_to\" edo \"traverse_to\" eta ondoren TALES espresio bat. Esaterako: \"redirect_to: string:thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Eremuen balioen aurretik erakutsiko den testua."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Formularioa balidatzean exekutatuko den TALES espresioa. Erabili 'value' aldagaia balidaziorako, bertan egongo da-eta eremuaren balioa. Itzuli False balio boolearra balioa zuzena bada; bestela itzuli errore mezua. Adb.: \"python:test(value='arrautzak', False, 'Balioa arrautzak izan behar da')\" idatzi gero, eremuaren balioa \"arrautzak\" izan beharko da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr " "
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Deskargatuko den fitxategiaren lehenengo lerroak eremuen izenak txertatu nahi dituzu?"
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Aukeratu eremu honetan erabiliko diren balidadoreak."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Mezuan X-Goiburuko bezala txertatuko diren HTTP goiburukoak aukeratu."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "Inportatu"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Balidazioaren osteko scripta"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Formularioa ezartzeko scripta"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCC espresioa"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CC espresioa"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "CSRF babesa"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Eremu-multzoaren defektuzko etiketa"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Deskargatzeko formatua"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Formularioaren epilogoa"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Exekuzio baldintza"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Eremuaren widgeta"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "SSL konexioa derrigortu"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Eremu-multzoak fitxa bihurtu"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Pertsonalizatutako akzioa"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Goiburuko gehigarriak"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC jasotzaileak"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Gorputza (sinadura)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Gorputza (ondoren gehituko dena)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Gorputza (aurretik gehituko dena)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Mezuaren txantilioia"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Mezuaren formatua"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC jasotzaileak"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Jasotzailearen eposta"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Jasotzailearen izena"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Reply-To goiburukoa nondik atera"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Gaia"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Mezuaren gaia nondik atera"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Mezuaren jasotzailea nondik atera"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Goiburukoak txertatu"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Hutsik daudenak sartu"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "Etiketa"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Hutsik daudenak sartu"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Eremu guztiak sartu"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Erantzunak erakutsi"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Formularioaren metodoa"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Formularioaren prologoa"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Jasotzailearen espresioa"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Reset botoiaren etiketa"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Etiketa aberatsa"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Datu gehigarriak"
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Gordetako eremuak"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Scriptaren gorputza"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Scriptaren proxy-rola"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Bidaltzailearen espresioa"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Zerbitzariaren aldeko aldagaia"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Eremu guztiak erakutsi"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Reset botoia erakutsi"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Erantzunak erakutsi"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Gaiaren espresioa"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Bidalketa botoiaren etiketa"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Bidalketa botoiaren etiketa pertsonalizatua"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Defektuzko espresioa"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Aktibatzeko espresioa"
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Eskertzaren laburpena"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Eskertzaren epilogoa"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Arrakasta akzio pertsonalizatua"
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Arrakasta akzio pertsonalizatu-mota"
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Eskertzaren prologoa"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Eskertzaren izenburua"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Balidadore pertsonalizatua"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Babesa"
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Eremu izenak sartu"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Goiburukoak"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Fitxategia handiegia da"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "CSV: komekin banatutako balioak"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Bidalketaren data/ordua"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "TSV: Tabulazioekin banatutako balioak"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2017-10-22 16:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,1010 +16,1019 @@ msgstr ""
 "Language: eu\n"
 "X-Generator: Poedit 1.8.7.1\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} elementu gorde dira"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Akzio mota"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Akzioen eredua"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Akzio berria gehitu"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Helbideak"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Onartutako eremuak"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Guztiak ezabatu"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Formularioaren akzioak konfiguratu"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Formularioaren eremuak konfiguratu"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "'${fieldname}' akzioa aldatu"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Akzioen XML eredua editatu"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Eremuen XML eredua editatu"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Esportatu"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Eremuen eredua"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulario ondo inportatu da."
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Goiburukoak"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Inportatu"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Ez dira loturak onartzen."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Eposta helbideen zerrenda bat izan behar da (komarekin banatuta)."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Aukeratuta egon behar da"
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Ezin da aukeratuta egon"
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Gainidazketak"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Bidalketaren data/ordua"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Berbideratu (redirect_to)"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Garbitu"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etiketa aberatsa"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Gordetako datuak"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Eskertza-orria"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Eremu hauek gehitu daitezke formularioetan."
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Joan (traverse_to)"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Balidadoreak"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Garbitu"
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Bidali"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Eskerrik asko bidalketagatik"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Eskerrik asko"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Aktibatuz gero, eremu honen balioa akzioek erabiliko dute bakarrik eta ez da formularioan erakutsiko."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} goiburukoa"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Formularioa ondo balidatu ostean baina edozein akzio exekutatu edo eskertza orrialde erakutsi baino lehen exekutatuko den TALES espresioa. Formularioan sartutako datuak request.form-en egongo dira. Utzi hutsik ez baduzu behar. Eremu honen erabilpen arruntena, formularioko datuak garbitzeko edo akzio gisa erabiliko den python script bati deitzea da. Espresioak itzulitako edozein erantzun ez da kontuan hartuko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Formularioa erakustean exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Eremu honen erabilpen arruntena formularioaren eremuen defektuzko balioak ezarriko dituen python script bati deitzea da, horretarako request.form-en balioak ezarriko dituelarik. Espresioak itzulitako edozein erantzun ez da kontuan hartuko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "BCC zerrendaren balioak gainidatziko dituen TALES espresioa. Kontuz honetarako balioztatu gabeko edozein balio erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-kate zerrenda bat itzuli behar du. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "CC zerrendaren balioak gainidatziko dituen TALES espresioa. Kontuz honetarako balioztatu gabeko edozein balio erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-kate zerrenda bat itzuli behar du. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Aktibatuta badago CSRF edo Cross-Site-Request-Forgery deritzon babesa erabiltzen du. Izan kontuan kasu horretan HTTP POST erako akzioak bakarrik onartuko direla."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Eremu honek defektuzko eremu-multzoaren etiketa aldatzen uzten dizu."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Formularioaren eremuen ostean agertuko den testua."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Akzio hau exekutatu ala ez erabakitzeko exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak balio boolear bat itzuli behar du; True itzuli akzioa exekutatzeko. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr " "
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Aktibatuta badago, automatikoki HTTPS darabilen helbidera berbideratuko da formularioa (https://). Ondo funtzionatzeko aurrez web zerbitzaria konfiguratu behar duzu HTTPS protokoloarekin funtzionatu dezan eta eskaerak Plone zerbitzari bidera ditzan."
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr " "
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Formularioaren 'action' atributua gainidazteko erabili eremu hau. Idatzi hemen formularioaren datuak zein URLtara bidali behar diren. Hau erabiliz gero formularioaren balidazioa, eta konfiguratutako akzioak eta eskertza-orriak ez dira kontuan hartuko."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Eposta mezuan gehitu beharreko goiburu gehigarriak. RFC822rekin bat datozen goiburuak bakarrik erabili."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "BCC kopia ezkutu bat jasoko duten helbideak."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Mezuaren oinean gehituko den testua, mezuaren azpian agertuko da marradun lerro baten ostean."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Mezuaren gorputzean dauden eremuei ondoren gehituko zaien testua"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Mezuaren gorputzean dauden eremuei aurretik gehituko zaien testua"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Mezuaren gorputza sortzeko erabiliko den txantilioia (ZPT). Ez duzu zertan aldatu, baina TAL baldin badakizu, bidalitako mezuaren itxura osorik pertsonalizatu dezakezu."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Mezuaren mime-type-a zehaztu. Zer egiten ari zaren badakizu bakarrik aldatu. Utzi hutsik defektuzko portaerarako."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "CC kopia bat jasoko duten helbideak."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Jasotzailearen eposta helbidea"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Jasotzailearen izena"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Reply-To goiburukoaren balioa ateratzeko formularioko eremua aukeratu. OHARRA: aukeratu duzun eremuarentzat eposta balidatzailea aktibatzea gomendatzen dizugu"
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Mezuaren gaia. Hauxe erabiliko da ez baduzu gai eremua erabili edo eremua hutsik badago"
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Mezuaren gaia formularioko zein eremutatik atera aukeratu."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "To goiburuaren balioa (mezuaren jasotzailea) zein eremutatik atera aukeratu. \"None\" ez den beste zerbait aukeratzen baduzu, honek \"Jasotzaileak\" goiko ezarpena gainidatziko du. Kontuz ibili balidatu gabeko balioak onartzearekin."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "HTML goiburuan edukia txertatu dezakezu. Erabilpen arruntena CSS eta JavaScripta txertatzea izaten da. Idatzi testu-kate bat itzuliko duen TALES espresio bat. Testu katea interpretatu gabe txertatuko da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Aukeratuta badago baliorik jaso ez duten formularioko eremuen etiketak erakutsi egingo dira. "
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Aukeratuta badago baliorik jaso ez duten formularioko eremuen etiketak erakutsi egingo dira bidalitako epostan. "
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Aukeratuta badago eremu guztien balioak (etiketak eta fitxategiak izan ezik) sartuko dira eposta mezuan. Aukeratzen baduzu, beheko kutxako aukerak ez dira kontuan hartuko."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Aukeratu zein eremuren balioak bidali nahi dutuzun eposta mezuan."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr " "
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Formularioko eremuen aurretik agertuko den testua."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Jasotzailearen epostaren balioa gainidazteko exekutatuko den TALES espresioa. Kontuz ibili balidatu gabeko balioak erabiltzearekin. Utzi hutsik ez baduzu behar. Espresioak testu-katea bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr " "
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Formularioaren datuekin batera gorde nahi duzun beste edozein balio gehigarri aukeratu."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Aukeratu zein balio gorde nahi dituzun. Hutsik uzten baduzu, eremu guztien balioak gordeko dira."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Idatzi hemen zuren scripta"
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Scripta zein rolekin exekutatuko den."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "\"From\" (bidaltzailea) goiburukoaren balioa gainidazteko erabiliko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Aukeratuta badago eremu guztien balioak erakutsiko ditu (etiketak eta fitxategiak izan ezik). Aukeratzen baduzu, beheko kutxako aukerak ez dira kontuan hartuko."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr " "
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Aukeratu zein eremuren balioak erakutsi nahi dituzun eskertza-orrian."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Epostaren gaia gainidazteko exekutatuko den TALES espresioa. Utzi hutsik ez baduzu behar. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr " "
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Bidalketa botoiaren etiketa aldatzeko TALES espresioa. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Eremuaren defektuzko balioa lortzeko formularioa erakustean exekutatuko den TALES espresioa. Utzi hutsik behar ez baduzu. Espresioak testu-kate bat itzuli beharko luke. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Eremua aktibo egongo den edo ez erabakitzeko formularioa erakustean exekutatuko den TALES espresioa. Espresioak True balio boolearra itzuli beharko du eremua formularioan erakustarazi nahi baduzu, aldiz, False ez bada erakutsi behar. Utzi hutsik behar ez baduzu: horrela eremua erakutsi egingo da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Eskertza-orrian erabiliko da."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Eremuen balioen ostean erakutsiko den testua."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Erabili eremu hau eskertza orriaren ordez, formularioaren akzioaren ondoren erakutsiko den helbidea zehazteko. Erabilpen arrunta arrakasta orrialde bat edo script bat exekutatzea da. Utzi hutsik behar ez baduzu. Bestela CMFFormController erako akzio gisa idatzi behar duzu. Adibidez: \"redirect_to\" edo \"traverse_to\" eta ondoren TALES espresio bat. Esaterako: \"redirect_to: string:thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Erabili eremu hau eskertza orriaren ordez, formularioaren akzioaren ondoren erakutsiko den helbidea zehazteko. Erabilpen arrunta arrakasta orrialde bat edo script bat exekutatzea da. Utzi hutsik behar ez baduzu. Bestela CMFFormController erako akzio gisa idatzi behar duzu. Adibidez: \"redirect_to\" edo \"traverse_to\" eta ondoren TALES espresio bat. Esaterako: \"redirect_to: string:thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Eremuen balioen aurretik erakutsiko den testua."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Formularioa balidatzean exekutatuko den TALES espresioa. Erabili 'value' aldagaia balidaziorako, bertan egongo da-eta eremuaren balioa. Itzuli False balio boolearra balioa zuzena bada; bestela itzuli errore mezua. Adb.: \"python:test(value='arrautzak', False, 'Balioa arrautzak izan behar da')\" idatzi gero, eremuaren balioa \"arrautzak\" izan beharko da. OHARRA: espresio hau ebaluatzean erroreren bat gertatzen bada, formularioaren bistan errore mezua agertuko da."
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr " "
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Deskargatuko den fitxategiaren lehenengo lerroak eremuen izenak txertatu nahi dituzu?"
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Aukeratu eremu honetan erabiliko diren balidadoreak."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Mezuan X-Goiburuko bezala txertatuko diren HTTP goiburukoak aukeratu."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "Inportatu"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Balidazioaren osteko scripta"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Formularioa ezartzeko scripta"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCC espresioa"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CC espresioa"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "CSRF babesa"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Eremu-multzoaren defektuzko etiketa"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Deskargatzeko formatua"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Formularioaren epilogoa"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Exekuzio baldintza"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Eremuaren widgeta"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "SSL konexioa derrigortu"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Eremu-multzoak fitxa bihurtu"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Pertsonalizatutako akzioa"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Goiburuko gehigarriak"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC jasotzaileak"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Gorputza (sinadura)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Gorputza (ondoren gehituko dena)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Gorputza (aurretik gehituko dena)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Mezuaren txantilioia"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Mezuaren formatua"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC jasotzaileak"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Jasotzailearen eposta"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Jasotzailearen izena"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Reply-To goiburukoa nondik atera"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Gaia"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Mezuaren gaia nondik atera"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Mezuaren jasotzailea nondik atera"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Goiburukoak txertatu"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Hutsik daudenak sartu"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "Etiketa"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Hutsik daudenak sartu"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Eremu guztiak sartu"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Erantzunak erakutsi"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Formularioaren metodoa"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Formularioaren prologoa"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Jasotzailearen espresioa"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Reset botoiaren etiketa"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Etiketa aberatsa"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Datu gehigarriak"
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Gordetako eremuak"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Scriptaren gorputza"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Scriptaren proxy-rola"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Bidaltzailearen espresioa"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Zerbitzariaren aldeko aldagaia"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Eremu guztiak erakutsi"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Reset botoia erakutsi"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Erantzunak erakutsi"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Gaiaren espresioa"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Bidalketa botoiaren etiketa"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Bidalketa botoiaren etiketa pertsonalizatua"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Defektuzko espresioa"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Aktibatzeko espresioa"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Eskertzaren laburpena"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Eskertzaren epilogoa"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Arrakasta akzio pertsonalizatua"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Arrakasta akzio pertsonalizatu-mota"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Eskertzaren prologoa"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Eskertzaren izenburua"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Balidadore pertsonalizatua"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Babesa"
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Eremu izenak sartu"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Goiburukoak"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Fitxategia handiegia da"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "CSV: komekin banatutako balioak"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Bidalketaren data/ordua"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "TSV: Tabulazioekin banatutako balioak"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/fr/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/fr/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,1019 +14,1019 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} soumissions(s) sauvegardées(s)"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr "Un constructeur de formulaire"
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Type d'action"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modèle des actions"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Ajouter une nouvelle action"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Destinataires"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Avancé"
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Champs autorisés"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "Délimiteur CSV"
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "Le délimiteur CSV est requis."
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Choisissez un élément."
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Effacer tout"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr "Commentaires"
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Définir les actions sur le formulaire"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Définir les champs du formulaire"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr "Envoie par courriel les réponses au formulaire"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "Formulaire"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Editer l'action '${fieldname}'"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Editer le modèle XML des actions"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Editer le modèle XML des champs"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr "Entrez les choix autorisés (un par ligne)."
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr "Erreur: tous les éléments du modèle doivent être 'schema'"
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr "Erreur: la balise racine doit être 'model'"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Exporter"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modèle des champs"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr "Envoi du formulaire"
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulaire importé."
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "En-tête"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Importer"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Les liens ne sont pas autorisés."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Liste des éléments de sauvegarde de données"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr "Envoi de courriels"
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Doit être une liste valide d'adresses courriels (séparées par des virgules)."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Doit être cochée."
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Doit être décochée."
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Aucun élément disponible."
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Surcharges"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr "Réponses possibles"
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr "Questions possibles"
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Date/Heure d'envoi"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Rediriger vers"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Réinitialisation"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etiquette riche"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr "Données sauvegardées"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Données sauvegardées"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Définissez le délimiteur CSV par défaut"
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr "Sujet"
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Page de remerciement"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Ces champs sont disponibles pour vos formulaires."
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traverser vers"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validateurs"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr "Voir"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Votre adresse courriel"
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Réinitialiser"
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Envoyer"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Merci pour votre retour."
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Merci"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Marquer ce champ comme une valeur à injecter dans la requête pour une utilisation par les éléments d'action, et qui n'est pas modifiable ou exposée à l'utilisateur."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr "Paramètres Easyform"
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} en-tête"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Une expression TALES qui sera appelée après la validation réussie du formulaire, mais avant d'appeler un élément d'action (le cas échéant) ou d'afficher une page de remerciement. L'utilisation la plus courante de ce champ consiste à appeler un script Python pour nettoyer l'entrée du formulaire ou pour créer un script d'action alternative. Toute valeur renvoyée par l'expression est ignorée. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Une expression TALES qui sera appelée lors de l'affichage du formulaire. Laisser vide si inutile. L'utilisation la plus courante de ce champ consiste à appeler un script Python qui définit les valeurs par défaut pour plusieurs champs en pré-remplissant request.form. Toute valeur renvoyée par l'expression est ignorée. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur autrement saisie pour la liste CCI. Vous êtes fortement mis en garde contre l'utilisation de données non validées de la demande à cette fin. Laisser vide si inutile. Votre expression doit être évaluée comme une séquence de chaînes de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur autrement saisie pour la liste CC. Vous êtes fortement mis en garde contre l'utilisation de données non validées de la demande à cette fin. Laisser vide si inutile. Votre expression doit être évaluée comme une séquence de chaînes de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Cocher cette case pour utiliser la protection CSRF. Seuls les envois en POST seront alors autorisés."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Ce champ permet de changer le titre du groupe de champs par défaut"
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Ce texte sera affiché après les champs du formulaire."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Une expression TALES qui sera évaluée pour déterminer s'il faut ou non exécuter cette action. Laissez vide si inutile et l'action sera exécutée. Votre expression doit être évaluée comme un booléen; renvoie True si vous souhaitez que l'action s'exécute. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Rediriger le formulaire vers une version SSL de lui-même (https://) s'il est accessible via une URL non SSL (http://). Pour fonctionner correctement, cela nécessite un serveur Web qui a été configuré pour gérer le protocole HTTPS sur le port 443 et le transmettre à Zope."
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Utilisez ce champ pour remplacer l'attribut action du formulaire. Spécifiez une URL sur laquelle le formulaire sera envoyé. Cela contournera la validation du formulaire, l'élément d'action de réussite et la page de remerciement."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Lignes d'en-tête de courriel supplémentaires. Utilisez uniquement des en-têtes conformes à la RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Adresses courriel qui recevront le courriel en CCI"
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Texte utilisé comme pied de page, délimité du corps du message par une ligne pointillée."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Texte ajouté aux champs listés dans le contenu du courriel"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Texte ajouté avant les champs dans le contenu du courriel"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Il s'agit d'un modèle de page Zope utilisé pour le rendu du corps du courriel. Vous n'avez pas besoin de le modifier, mais si vous connaissez TAL (Zope's Template Attribute Language), vous avez tout le pouvoir de personnaliser vos courriels sortants."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Définissez le type MIME du corps du message. Modifiez ce paramètre uniquement si vous savez exactement ce que vous faites. Laissez-le vide pour le comportement par défaut."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Adresses courriel qui recevront le courriel en CC"
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "L'adresse courriel du destinataire"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Le nom du destinataire du formulaire envoyé par courriel"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Choisissez un champ de formulaire à partir duquel vous souhaitez extraire l'entrée pour l'en-tête \"Reply-To\". REMARQUE: Vous devez activer la vérification de l'adresse courriel pour le champ désigné."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Objet du message. Ceci est utilisé si vous ne spécifiez pas de champ d'objet ou si le champ est vide."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Choisissez un champ de formulaire à partir duquel vous souhaitez extraire l'objet du courriel."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Choisissez un champ de formulaire à partir duquel vous souhaitez extraire l'entrée pour l'en-tête \"To\". Si vous choisissez autre chose que \"Aucun\", cela remplacera le paramètre d'adresse courriel \"Destinataire\" ci-dessus. Soyez très prudent lorsque vous autorisez une entrée utilisateur non protégée à cette fin."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Ce champ de remplacement vous permet d'insérer du contenu dans le head xhtml. L'utilisation typique consiste à ajouter du CSS ou du JavaScript personnalisé. Spécifiez une expression TALES renvoyant une chaîne de caractères. Cette chaîne sera insérée sans interprétation. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Indique si un champ doit être caché."
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Afficher les titres des champs même s'ils n'ont reçu aucune entrée. Décochez pour laisser les champs vides hors de la liste."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Cochez cette case pour inclure les titres des champs qui n'ont reçu aucune entrée. Décochez-la pour ne pas reprendre les champs sans saisie dans le courriel."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Cochez cette case pour inclure l'entrée de tous les champs (à l'exception des champs de libellé et de fichier). Si vous cochez cette case, les choix dans la sélection ci-dessous seront ignorés."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Sélectionnez les champs que vous souhaitez inclure dans le courriel."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr "Optionnel, définit l'attribut name sur le conteneur de formulaire. Peut être utilisé pour l'analyse statistiques des formulaires."
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Ce texte sera affiché au-dessus des champs du formulaire."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur saisie pour l'adresse courriel du destinataire. Vous êtes fortement mis en garde contre l'utilisation de données non validées de la requête à cette fin. Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Sélectionnez les données supplémentaires que vous souhaitez sauvegarder avec les champs du formulaire."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Sélectionnez les champs que vous souhaitez inclure dans les données sauvegardées. Si vide, tous les champs seront sauvegardés."
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Entrez votre script ici."
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rôle à utiliser pour exécuter le script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Envoyer un fichier CSV contenant les valeurs renseignées dans le formulaire en pièce jointe."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr "Inclure l'en-tête CSV/XLSX dans les pièces jointes."
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr "Envoyer un fichier XLSX contenant les valeurs renseignées dans le formulaire en pièce jointe."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Envoyer un fichier XML contenant les valeurs renseignées dans le formulaire en pièce jointe."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer l'en-tête \"From\". Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Afficher les entrées de tous les champs (à l'exception des champs de libellé et de fichier). Si vous cochez cette case, les choix dans la case de sélection ci-dessous seront ignorés."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Choisissez les champs dont vous souhaitez afficher les entrées sur la page de remerciement."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur saisie pour l'en-tête de l'objet du courriel. Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Ce champ de remplacement vous permet de modifier le libellé du bouton d'envoi. L'utilisation typique consiste à définir un libellé avec des paramètres de la requête. Spécifiez une expression TALES renvoyant une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Une expression TALES qui sera évaluée lors de l'affichage du formulaire pour obtenir la valeur par défaut du champ. Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Une expression TALES qui sera évaluée lors de l'affichage du formulaire pour déterminer si le champ est activé ou non. Votre expression doit être évaluée comme True si le champ doit être inclus dans le formulaire, False s'il doit être omis. Laissez ce champ d'expression vide s'il n'est pas nécessaire: le champ sera inclus. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Utilisé dans la page de remerciement."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Ce texte sera affiché après les champs."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Utilisez ce champ à la place de la page de remerciements pour déterminer l'action finale après avoir appelé votre élément d'action (si vous en avez un). Vous l'utiliserez généralement pour un modèle ou un script de réussite personnalisé. Laisser vide si inutile. Sinon, spécifiez comme vous le feriez un type d'action et un argument CMFFormController, avec le type d'action à exécuter (par exemple, \"redirect_to\" ou \"traverse_to\") et une expression TALES. Par exemple, \"Redirect to\" et \"string:page-merci\" redirigeraient vers \"page-merci\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Utilisez ce champ à la place de la page de remerciements pour déterminer l'action finale après avoir appelé votre élément d'action (si vous en avez un). Vous l'utiliserez généralement pour un modèle ou un script de réussite personnalisé. Laisser vide si inutile. Sinon, spécifiez comme vous le feriez un type d'action et un argument CMFFormController, avec le type d'action à exécuter (par exemple, \"redirect_to\" ou \"traverse_to\") et une expression TALES. Par exemple, \"Redirect to\" et \"string:page-merci\" redirigeraient vers \"page-merci\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Ce texte sera affiché au-dessus des champs."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Une expression TALES qui sera évaluée lors de la validation du formulaire. Validez par rapport à 'value', qui contiendra l'entrée de champ. Renvoie False si valide; s'il n'est pas valide, renvoie un message d'erreur en chaîne de caractères. Par exemple, \"python: test(value=='œufs', False, 'cela doit être des œufs')\" nécessitera \"œufs\" pour l'entrée. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Reprendre le nom des colonnes à la première ligne du fichier téléchargé."
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Sélectionnez les validateurs à utiliser sur ce champ"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Sélectionnez tous les éléments des en-têtes HTTP que vous souhaitez insérer en tant qu'en-têtes X- dans le message."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "Importer"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script post-validation"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de configuration du formulaire"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Expression CCI"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Expression CC"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Protection CSRF"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personnalisé"
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Libellé personnalisé du groupe de champs par défaut"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Format de téléchargement"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epilogue du formulaire"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condition d'exécution"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Widget du champ"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forcer la connexion SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Transformer les groupes de champs en onglets"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Action personnalisée du formulaire"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "En-têtes additionnels"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinataires CCI"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Texte (signature)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Texte (ajouté après)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Texte (ajouté avant)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Modèle du corps du courriel"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Format du courriel"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinataires CC"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Adresse courriel du destinataire"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nom complet du destinataire"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Récupérer le Reply-To depuis"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Sujet"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Récupérer le sujet depuis"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Récupérer le destinataire depuis"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Injection d'en-tête"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Caché"
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Inclure les champs vides"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "Libellé"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Inclure les champs vides"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Inclure tous les champs"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr "Envoi de courriel"
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Afficher les réponses"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Méthode des formulaires"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr "Attribut name"
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prologue du formulaire"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Expression pour le destinataire"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Libellé du bouton de réinitialisation"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Libellé riche"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "Sauvegarde des données"
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Données supplémentaires"
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Champs sauvegardés"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Rôle proxy"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Envoyer les données CSV en attaché"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr "Inclure les en-têtes dans le fichier CSV/XLSX attaché"
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr "Envoyer les données XLSX en attaché"
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Envoyer les données XML en attaché"
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Expression pour l'expéditeur"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variable coté serveur"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Montrer tous les champs"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Afficher le bouton de réinitialisation"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Afficher les réponses"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Expression pour le sujet"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Libellé du bouton d'envoi"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Libellé personnalisé pour le bouton d'envoi"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Expression par défaut"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Expression d'activation"
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Résumé du remerciement"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epilogue du remerciement"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Action de réussite personnalisée"
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Type d'action de réussite personnalisé"
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prologue du remerciement"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Titre du remerciement"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validateur personnalisé"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Protection Unload"
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Inclure les noms des colonnes"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "En-têtes HTTP"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Le type de fichier '${ftype}' n'est pas autorisé!"
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Le fichier est plus gros que la taille maximale de ${size} octets!"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr "Les données sauvegardées de ${formname} stockées dans l'élément ${adapter}"
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Valeurs séparées par des virgules"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Date/Heure d'envoi"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Valeurs séparées par des tabulations"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/fr/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/fr/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,1010 +14,1019 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} soumissions(s) sauvegardées(s)"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr "Un constructeur de formulaire"
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Type d'action"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modèle des actions"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Ajouter une nouvelle action"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Destinataires"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Avancé"
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Champs autorisés"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "Délimiteur CSV"
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "Le délimiteur CSV est requis."
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Choisissez un élément."
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Effacer tout"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr "Commentaires"
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Définir les actions sur le formulaire"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Définir les champs du formulaire"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr "Envoie par courriel les réponses au formulaire"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "Formulaire"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Editer l'action '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Editer le modèle XML des actions"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Editer le modèle XML des champs"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr "Entrez les choix autorisés (un par ligne)."
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr "Erreur: tous les éléments du modèle doivent être 'schema'"
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr "Erreur: la balise racine doit être 'model'"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Exporter"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modèle des champs"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr "Envoi du formulaire"
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulaire importé."
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "En-tête"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Importer"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Les liens ne sont pas autorisés."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Liste des éléments de sauvegarde de données"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr "Envoi de courriels"
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Doit être une liste valide d'adresses courriels (séparées par des virgules)."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Doit être cochée."
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Doit être décochée."
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Aucun élément disponible."
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Surcharges"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr "Réponses possibles"
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr "Questions possibles"
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Date/Heure d'envoi"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Rediriger vers"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Réinitialisation"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etiquette riche"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr "Données sauvegardées"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Données sauvegardées"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Définissez le délimiteur CSV par défaut"
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr "Sujet"
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Page de remerciement"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Ces champs sont disponibles pour vos formulaires."
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traverser vers"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validateurs"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr "Voir"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Votre adresse courriel"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Réinitialiser"
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Envoyer"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Merci pour votre retour."
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Merci"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Marquer ce champ comme une valeur à injecter dans la requête pour une utilisation par les éléments d'action, et qui n'est pas modifiable ou exposée à l'utilisateur."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr "Paramètres Easyform"
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} en-tête"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Une expression TALES qui sera appelée après la validation réussie du formulaire, mais avant d'appeler un élément d'action (le cas échéant) ou d'afficher une page de remerciement. L'utilisation la plus courante de ce champ consiste à appeler un script Python pour nettoyer l'entrée du formulaire ou pour créer un script d'action alternative. Toute valeur renvoyée par l'expression est ignorée. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Une expression TALES qui sera appelée lors de l'affichage du formulaire. Laisser vide si inutile. L'utilisation la plus courante de ce champ consiste à appeler un script Python qui définit les valeurs par défaut pour plusieurs champs en pré-remplissant request.form. Toute valeur renvoyée par l'expression est ignorée. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur autrement saisie pour la liste CCI. Vous êtes fortement mis en garde contre l'utilisation de données non validées de la demande à cette fin. Laisser vide si inutile. Votre expression doit être évaluée comme une séquence de chaînes de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur autrement saisie pour la liste CC. Vous êtes fortement mis en garde contre l'utilisation de données non validées de la demande à cette fin. Laisser vide si inutile. Votre expression doit être évaluée comme une séquence de chaînes de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Cocher cette case pour utiliser la protection CSRF. Seuls les envois en POST seront alors autorisés."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Ce champ permet de changer le titre du groupe de champs par défaut"
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Ce texte sera affiché après les champs du formulaire."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Une expression TALES qui sera évaluée pour déterminer s'il faut ou non exécuter cette action. Laissez vide si inutile et l'action sera exécutée. Votre expression doit être évaluée comme un booléen; renvoie True si vous souhaitez que l'action s'exécute. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Rediriger le formulaire vers une version SSL de lui-même (https://) s'il est accessible via une URL non SSL (http://). Pour fonctionner correctement, cela nécessite un serveur Web qui a été configuré pour gérer le protocole HTTPS sur le port 443 et le transmettre à Zope."
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Utilisez ce champ pour remplacer l'attribut action du formulaire. Spécifiez une URL sur laquelle le formulaire sera envoyé. Cela contournera la validation du formulaire, l'élément d'action de réussite et la page de remerciement."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Lignes d'en-tête de courriel supplémentaires. Utilisez uniquement des en-têtes conformes à la RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Adresses courriel qui recevront le courriel en CCI"
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Texte utilisé comme pied de page, délimité du corps du message par une ligne pointillée."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Texte ajouté aux champs listés dans le contenu du courriel"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Texte ajouté avant les champs dans le contenu du courriel"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Il s'agit d'un modèle de page Zope utilisé pour le rendu du corps du courriel. Vous n'avez pas besoin de le modifier, mais si vous connaissez TAL (Zope's Template Attribute Language), vous avez tout le pouvoir de personnaliser vos courriels sortants."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Définissez le type MIME du corps du message. Modifiez ce paramètre uniquement si vous savez exactement ce que vous faites. Laissez-le vide pour le comportement par défaut."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Adresses courriel qui recevront le courriel en CC"
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "L'adresse courriel du destinataire"
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Le nom du destinataire du formulaire envoyé par courriel"
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Choisissez un champ de formulaire à partir duquel vous souhaitez extraire l'entrée pour l'en-tête \"Reply-To\". REMARQUE: Vous devez activer la vérification de l'adresse courriel pour le champ désigné."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Objet du message. Ceci est utilisé si vous ne spécifiez pas de champ d'objet ou si le champ est vide."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Choisissez un champ de formulaire à partir duquel vous souhaitez extraire l'objet du courriel."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Choisissez un champ de formulaire à partir duquel vous souhaitez extraire l'entrée pour l'en-tête \"To\". Si vous choisissez autre chose que \"Aucun\", cela remplacera le paramètre d'adresse courriel \"Destinataire\" ci-dessus. Soyez très prudent lorsque vous autorisez une entrée utilisateur non protégée à cette fin."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Ce champ de remplacement vous permet d'insérer du contenu dans le head xhtml. L'utilisation typique consiste à ajouter du CSS ou du JavaScript personnalisé. Spécifiez une expression TALES renvoyant une chaîne de caractères. Cette chaîne sera insérée sans interprétation. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Indique si un champ doit être caché."
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Afficher les titres des champs même s'ils n'ont reçu aucune entrée. Décochez pour laisser les champs vides hors de la liste."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Cochez cette case pour inclure les titres des champs qui n'ont reçu aucune entrée. Décochez-la pour ne pas reprendre les champs sans saisie dans le courriel."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Cochez cette case pour inclure l'entrée de tous les champs (à l'exception des champs de libellé et de fichier). Si vous cochez cette case, les choix dans la sélection ci-dessous seront ignorés."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Sélectionnez les champs que vous souhaitez inclure dans le courriel."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr "Optionnel, définit l'attribut name sur le conteneur de formulaire. Peut être utilisé pour l'analyse statistiques des formulaires."
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Ce texte sera affiché au-dessus des champs du formulaire."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur saisie pour l'adresse courriel du destinataire. Vous êtes fortement mis en garde contre l'utilisation de données non validées de la requête à cette fin. Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Sélectionnez les données supplémentaires que vous souhaitez sauvegarder avec les champs du formulaire."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Sélectionnez les champs que vous souhaitez inclure dans les données sauvegardées. Si vide, tous les champs seront sauvegardés."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Entrez votre script ici."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rôle à utiliser pour exécuter le script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Envoyer un fichier CSV contenant les valeurs renseignées dans le formulaire en pièce jointe."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr "Inclure l'en-tête CSV/XLSX dans les pièces jointes."
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr "Envoyer un fichier XLSX contenant les valeurs renseignées dans le formulaire en pièce jointe."
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Envoyer un fichier XML contenant les valeurs renseignées dans le formulaire en pièce jointe."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer l'en-tête \"From\". Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Afficher les entrées de tous les champs (à l'exception des champs de libellé et de fichier). Si vous cochez cette case, les choix dans la case de sélection ci-dessous seront ignorés."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Choisissez les champs dont vous souhaitez afficher les entrées sur la page de remerciement."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Une expression TALES qui sera évaluée pour remplacer toute valeur saisie pour l'en-tête de l'objet du courriel. Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Ce champ de remplacement vous permet de modifier le libellé du bouton d'envoi. L'utilisation typique consiste à définir un libellé avec des paramètres de la requête. Spécifiez une expression TALES renvoyant une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Une expression TALES qui sera évaluée lors de l'affichage du formulaire pour obtenir la valeur par défaut du champ. Laisser vide si inutile. Votre expression doit être évaluée comme une chaîne de caractères. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Une expression TALES qui sera évaluée lors de l'affichage du formulaire pour déterminer si le champ est activé ou non. Votre expression doit être évaluée comme True si le champ doit être inclus dans le formulaire, False s'il doit être omis. Laissez ce champ d'expression vide s'il n'est pas nécessaire: le champ sera inclus. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Utilisé dans la page de remerciement."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Ce texte sera affiché après les champs."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Utilisez ce champ à la place de la page de remerciements pour déterminer l'action finale après avoir appelé votre élément d'action (si vous en avez un). Vous l'utiliserez généralement pour un modèle ou un script de réussite personnalisé. Laisser vide si inutile. Sinon, spécifiez comme vous le feriez un type d'action et un argument CMFFormController, avec le type d'action à exécuter (par exemple, \"redirect_to\" ou \"traverse_to\") et une expression TALES. Par exemple, \"Redirect to\" et \"string:page-merci\" redirigeraient vers \"page-merci\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Utilisez ce champ à la place de la page de remerciements pour déterminer l'action finale après avoir appelé votre élément d'action (si vous en avez un). Vous l'utiliserez généralement pour un modèle ou un script de réussite personnalisé. Laisser vide si inutile. Sinon, spécifiez comme vous le feriez un type d'action et un argument CMFFormController, avec le type d'action à exécuter (par exemple, \"redirect_to\" ou \"traverse_to\") et une expression TALES. Par exemple, \"Redirect to\" et \"string:page-merci\" redirigeraient vers \"page-merci\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Ce texte sera affiché au-dessus des champs."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Une expression TALES qui sera évaluée lors de la validation du formulaire. Validez par rapport à 'value', qui contiendra l'entrée de champ. Renvoie False si valide; s'il n'est pas valide, renvoie un message d'erreur en chaîne de caractères. Par exemple, \"python: test(value=='œufs', False, 'cela doit être des œufs')\" nécessitera \"œufs\" pour l'entrée. ATTENTION: des erreurs dans l'évaluation de cette expression entraîneront une erreur sur l'affichage du formulaire."
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Reprendre le nom des colonnes à la première ligne du fichier téléchargé."
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Sélectionnez les validateurs à utiliser sur ce champ"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Sélectionnez tous les éléments des en-têtes HTTP que vous souhaitez insérer en tant qu'en-têtes X- dans le message."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "Importer"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script post-validation"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de configuration du formulaire"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Expression CCI"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Expression CC"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Protection CSRF"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personnalisé"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Libellé personnalisé du groupe de champs par défaut"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Format de téléchargement"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epilogue du formulaire"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condition d'exécution"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Widget du champ"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forcer la connexion SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Transformer les groupes de champs en onglets"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Action personnalisée du formulaire"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "En-têtes additionnels"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinataires CCI"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Texte (signature)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Texte (ajouté après)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Texte (ajouté avant)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Modèle du corps du courriel"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Format du courriel"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinataires CC"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Adresse courriel du destinataire"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nom complet du destinataire"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Récupérer le Reply-To depuis"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Sujet"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Récupérer le sujet depuis"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Récupérer le destinataire depuis"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Injection d'en-tête"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Caché"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Inclure les champs vides"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "Libellé"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Inclure les champs vides"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Inclure tous les champs"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr "Envoi de courriel"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Afficher les réponses"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Méthode des formulaires"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr "Attribut name"
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prologue du formulaire"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Expression pour le destinataire"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Libellé du bouton de réinitialisation"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Libellé riche"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "Sauvegarde des données"
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Données supplémentaires"
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Champs sauvegardés"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Rôle proxy"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Envoyer les données CSV en attaché"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr "Inclure les en-têtes dans le fichier CSV/XLSX attaché"
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr "Envoyer les données XLSX en attaché"
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Envoyer les données XML en attaché"
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Expression pour l'expéditeur"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variable coté serveur"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Montrer tous les champs"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Afficher le bouton de réinitialisation"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Afficher les réponses"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Expression pour le sujet"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Libellé du bouton d'envoi"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Libellé personnalisé pour le bouton d'envoi"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Expression par défaut"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Expression d'activation"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Résumé du remerciement"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epilogue du remerciement"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Action de réussite personnalisée"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Type d'action de réussite personnalisé"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prologue du remerciement"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Titre du remerciement"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validateur personnalisé"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Protection Unload"
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Inclure les noms des colonnes"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "En-têtes HTTP"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Le type de fichier '${ftype}' n'est pas autorisé!"
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Le fichier est plus gros que la taille maximale de ${size} octets!"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr "Les données sauvegardées de ${formname} stockées dans l'élément ${adapter}"
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Valeurs séparées par des virgules"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Date/Heure d'envoi"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Valeurs séparées par des tabulations"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2014-05-06 16.00+0000\n"
 "Last-Translator: Giorgio Borelli\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,1008 +15,1017 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.easyform\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} elemento/i salvato/i"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Tipo di azione"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modello azioni"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Aggiungi azione"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Indirizzi"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Avanzate"
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Campi consentiti"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "Separatore CSV"
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "Il separatore per il CSV è obbligatorio"
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Scegli un adattatore"
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Cancella i dati salvati"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Definisci le action del form"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Definisci i campi del form"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Modifica l'azione '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Modifica l'XML delle azioni"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Modifica l'XML dei campi"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Esporta"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modello dei campi"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Form importato."
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Intestazioni"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Importa"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Non sono consentiti link."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Lista degli adattatori per salvare i dati"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Dev'essere una lista di indirizzi email validi, separati da virgola."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Dev'essere selezionato."
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Dev'essere deselezionato"
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Nessun adattatore disponibile"
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Sovrascritture"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Invia Data/Ora"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Reindirizza a"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Annulla"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etichetta Avanzata"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Dati salvati"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Imposta un separatore predefinito per lo scarico del CSV"
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Pagina di ringraziamento"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Questi campi sono disponibili per le tue form"
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Passa attraverso a"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validatori"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr "Vista"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Annulla"
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Invia"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Grazie per averci contattato."
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Grazie"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Considera questo campo come un valore da inserire nella richiesta della form per essere usato dagli adattatori delle azioni e non modificabile da o mostrato al richiedente"
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} intestazione"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Una espressione TALES che sarà chiamata dopo che la form sarà validata con successo, ma prima di chiamare un adattatore per le azioni (se presente) o di mostrare la pagina di ringraziamento. L'input della forma sarà disponibile nel dizionario request.form. Lascia vuoto se non necessario. L'utilizzo più comune di questo campo è la chiamata di uno script python per pulire la form o uno script come chiamata alternativa. Ogni valore di ritorno dell'espressione è ignorato. NOTA BENE: gli errori nell'interpretazione di questa espressione causeranno un errore nella visualizzazione della form"
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr "Abilita l'autofocus sul primo input"
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Selezionare per abilitare la protezione Cross-Site Request Forgery (CSRF). Notare che verranno ammesse solo azioni HTTP con metodo Post."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Questo campo permette di personalizzare il titolo del fieldset di default."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Questo testo verrà mostrato dopo i campi del form."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Usare questo campo per sovrascrivere l'attributo action del form. Speficicare un URL al quale fare la post. Questo bypasserà la validazione dei dati, la gestione dell'invio andato a buon fine e la pagina di ringraziamento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Righe di e-mail-header aggiuntive. Usare solo stringhe conformi RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Indirizzi E-mail in copia nascosta (bcc)."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Testo usato come footer, staccato dal body principale con una linea tratteggiata."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Testo aggiunto sotto alla lista dei campi nel mail-body"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Testo aggiunto sopra alla lista dei campi nel mail-body"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Questo è uno Zope Page Template usato per creare il mail-body. Non è necessario modificarlo, ma se conosci TAL (il linguaggio di templating di Zope) hai il potere di personalizzare totalmente le e-mail inviate."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Definisci il mime-type per il mail-body. Cambia questo settaggio solo se sai esattamente quello che stai facendo. Lascia il campo vuoto per lasciare il comportamento di default."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Indirizzi E-mail in copia (cc)."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "L'indirizzo e-mail del destinatario."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Il nome completo del destinatario del form."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Scegli un campo del form dal quale vorresti estrarre l'indirizzo del destinatario. Se scegli qualcosa di diverso da \"-\", questo campo sovrascrive l'impostazione \"Indirizzo e-mail del destinatario\" precedente. Presta molta attenzione nell'utilizzare input dall'utente senza controlli."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Il campo è nascosto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Spuntare per mostrare i titoli dei campi che non sono stati compilati. Lasciare senza spunta per non mostrarli."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Spuntare per includere i titoli dei campi che non sono stati compilati. Lasciare senza spunta per non includerli nella mail."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Spuntare per includere tutti i campi nella mail inviata (tranne label e file). Se attivi questa opzione, le selezioni del box qui sotto verranno ignorate."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Scegli quali campi vuoi includere nella mail inviata."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Questo testo verrà mostrato sopra i campi del form."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Indica il tuo script qui"
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Spuntare per mostrare tutti i campi del form (tranne label e file). Se attivi questa opzione, le selezioni del box qui sotto verranno ignorate."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Scegli quali campi del form vuoi mostrare nella pagina di successo."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Usato nella pagina di ringraziamento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Questo testo verrà mostrato dopo i campi di input selezionati."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Questo testo verrà mostrato sopra la lista dei campi selezionati."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr ""
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Selezionare i validatori da usare per questo campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Scegli dalla lista quali HTTP header vorresti inserire come X- header nel messaggio."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "importa"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr "Autofocus"
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personalizzato"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Titolo del fieldset di default"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Formato di download"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epilogo del form"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condizioni di esecuzione"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forza connessione SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Mostra i fieldset in tab separati"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Action personalizata per il form"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Header aggiuntivi"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinatari in BCC"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Body (firma)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Body (aggiungi sotto)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Body (aggiungi sopra)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinatari in CC"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Indirizzo e-mail del destinatario."
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nome completo destinatario"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Estrai il Reply-To da"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Oggetto"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Estrai l'Oggetto da"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Estrai il Destinatario da"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr ""
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Nascosto"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Includi elementi vuoti"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Includi elementi vuoti"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Includi tutti i campi"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Mostra il responso"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Metodo del form"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prologo del form"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Testo del bottone di Annulla"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Etichetta Avanzata"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "Salva i dati"
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Campi salvati"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr ""
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variabili server-side"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Visualizza tutti i campi"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Mostra il bottone Annulla"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Mostra il responso"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Testo del bottone di invio"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Test personalizzato del bottone di invio"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr ""
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Testo riassuntivo"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epilogo pagina di ringraziamento"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prologo pagina di ringraziamento"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Titolo pagina di ringraziamento"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validatore personalizzato"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Includi i nomi delle colonne"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Valori separati da virgola"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Invia Data/Ora"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Valori separati da Tab"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2014-05-06 16.00+0000\n"
 "Last-Translator: Giorgio Borelli\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,1017 +15,1017 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.easyform\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} elemento/i salvato/i"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Tipo di azione"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modello azioni"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Aggiungi azione"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Indirizzi"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Avanzate"
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Campi consentiti"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "Separatore CSV"
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr "Il separatore per il CSV è obbligatorio"
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Scegli un adattatore"
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Cancella i dati salvati"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Definisci le action del form"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Definisci i campi del form"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Modifica l'azione '${fieldname}'"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Modifica l'XML delle azioni"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Modifica l'XML dei campi"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Esporta"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modello dei campi"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Form importato."
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Intestazioni"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Importa"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Non sono consentiti link."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Lista degli adattatori per salvare i dati"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Dev'essere una lista di indirizzi email validi, separati da virgola."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Dev'essere selezionato."
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Dev'essere deselezionato"
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Nessun adattatore disponibile"
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Sovrascritture"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Invia Data/Ora"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Reindirizza a"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Annulla"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Etichetta Avanzata"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Dati salvati"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Imposta un separatore predefinito per lo scarico del CSV"
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Pagina di ringraziamento"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Questi campi sono disponibili per le tue form"
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Passa attraverso a"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validatori"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr "Vista"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Annulla"
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Invia"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Grazie per averci contattato."
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Grazie"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Considera questo campo come un valore da inserire nella richiesta della form per essere usato dagli adattatori delle azioni e non modificabile da o mostrato al richiedente"
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} intestazione"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Una espressione TALES che sarà chiamata dopo che la form sarà validata con successo, ma prima di chiamare un adattatore per le azioni (se presente) o di mostrare la pagina di ringraziamento. L'input della forma sarà disponibile nel dizionario request.form. Lascia vuoto se non necessario. L'utilizzo più comune di questo campo è la chiamata di uno script python per pulire la form o uno script come chiamata alternativa. Ogni valore di ritorno dell'espressione è ignorato. NOTA BENE: gli errori nell'interpretazione di questa espressione causeranno un errore nella visualizzazione della form"
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr "Abilita l'autofocus sul primo input"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr ""
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Selezionare per abilitare la protezione Cross-Site Request Forgery (CSRF). Notare che verranno ammesse solo azioni HTTP con metodo Post."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Questo campo permette di personalizzare il titolo del fieldset di default."
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Questo testo verrà mostrato dopo i campi del form."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr ""
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr ""
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Usare questo campo per sovrascrivere l'attributo action del form. Speficicare un URL al quale fare la post. Questo bypasserà la validazione dei dati, la gestione dell'invio andato a buon fine e la pagina di ringraziamento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Righe di e-mail-header aggiuntive. Usare solo stringhe conformi RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Indirizzi E-mail in copia nascosta (bcc)."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Testo usato come footer, staccato dal body principale con una linea tratteggiata."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Testo aggiunto sotto alla lista dei campi nel mail-body"
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Testo aggiunto sopra alla lista dei campi nel mail-body"
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Questo è uno Zope Page Template usato per creare il mail-body. Non è necessario modificarlo, ma se conosci TAL (il linguaggio di templating di Zope) hai il potere di personalizzare totalmente le e-mail inviate."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Definisci il mime-type per il mail-body. Cambia questo settaggio solo se sai esattamente quello che stai facendo. Lascia il campo vuoto per lasciare il comportamento di default."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Indirizzi E-mail in copia (cc)."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "L'indirizzo e-mail del destinatario."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Il nome completo del destinatario del form."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr ""
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr ""
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Scegli un campo del form dal quale vorresti estrarre l'indirizzo del destinatario. Se scegli qualcosa di diverso da \"-\", questo campo sovrascrive l'impostazione \"Indirizzo e-mail del destinatario\" precedente. Presta molta attenzione nell'utilizzare input dall'utente senza controlli."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr ""
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Il campo è nascosto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Spuntare per mostrare i titoli dei campi che non sono stati compilati. Lasciare senza spunta per non mostrarli."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Spuntare per includere i titoli dei campi che non sono stati compilati. Lasciare senza spunta per non includerli nella mail."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Spuntare per includere tutti i campi nella mail inviata (tranne label e file). Se attivi questa opzione, le selezioni del box qui sotto verranno ignorate."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Scegli quali campi vuoi includere nella mail inviata."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Questo testo verrà mostrato sopra i campi del form."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 msgid "help_recipient_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr ""
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Indica il tuo script qui"
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr ""
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 msgid "help_sender_override_text"
 msgstr ""
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Spuntare per mostrare tutti i campi del form (tranne label e file). Se attivi questa opzione, le selezioni del box qui sotto verranno ignorate."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Scegli quali campi del form vuoi mostrare nella pagina di successo."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr ""
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Usato nella pagina di ringraziamento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Questo testo verrà mostrato dopo i campi di input selezionati."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Questo testo verrà mostrato sopra la lista dei campi selezionati."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr ""
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr ""
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Selezionare i validatori da usare per questo campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Scegli dalla lista quali HTTP header vorresti inserire come X- header nel messaggio."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "importa"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr ""
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr ""
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr "Autofocus"
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr ""
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr ""
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr ""
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personalizzato"
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Titolo del fieldset di default"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Formato di download"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epilogo del form"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condizioni di esecuzione"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr ""
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forza connessione SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Mostra i fieldset in tab separati"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Action personalizata per il form"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Header aggiuntivi"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinatari in BCC"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Body (firma)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Body (aggiungi sotto)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Body (aggiungi sopra)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr ""
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr ""
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinatari in CC"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Indirizzo e-mail del destinatario."
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nome completo destinatario"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Estrai il Reply-To da"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Oggetto"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Estrai l'Oggetto da"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Estrai il Destinatario da"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr ""
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Nascosto"
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Includi elementi vuoti"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Includi elementi vuoti"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Includi tutti i campi"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Mostra il responso"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Metodo del form"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prologo del form"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr ""
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Testo del bottone di Annulla"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Etichetta Avanzata"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "Salva i dati"
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Campi salvati"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr ""
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr ""
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr ""
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variabili server-side"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Visualizza tutti i campi"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Mostra il bottone Annulla"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Mostra il responso"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr ""
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Testo del bottone di invio"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Test personalizzato del bottone di invio"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr ""
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Testo riassuntivo"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epilogo pagina di ringraziamento"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prologo pagina di ringraziamento"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Titolo pagina di ringraziamento"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validatore personalizzato"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Includi i nomi delle colonne"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Valori separati da virgola"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Invia Data/Ora"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Valori separati da Tab"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/ja/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/ja/LC_MESSAGES/collective.easyform.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2021-03-31 11:45 +0900\n"
 "Last-Translator: Manabu TERADA <terada@cmscom.jp>\n"
 "Language-Team: None\n"
@@ -21,374 +21,378 @@ msgstr ""
 "Domain: collective.easyform\n"
 
 # 編集操作→Saved Data→Choose an adapterで選択→「〇 input(s) saved」
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items}件保存されています"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
 # Define form actions→「アクションを編集」→Add new action→「Action type」
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "アクションタイプ"
 
 # 場所不明
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "アクションモデル"
 
 # Define form actions→「アクションを編集」右上ボタン
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "新規アクションを追加"
 
 # Define form actions → actionsを編集→ mailer → settings → Edit Action 'mailer’→ addressing
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "アドレス指定"
 
 # EasyForm を編集→「Advanced」など
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr "上級者向け設定"
 
 # コントロールパネル内
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "追加許可フィールド"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
 # セーブデータ内　アダプターが存在するとき
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "アダプターを選択してください"
 
 # セーブデータ内など
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "全件削除"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
 # 編集操作→Define form actions
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "アクションの定義"
 
 # 編集操作→Define form fields
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "フィールドの定義"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
 # 授業内フォルダ→新規追加→Easyform
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
 # Define form actions→「actionsを編集」
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "‘${fieldname}‘のアクションを編集"
 
 # 開発者に問い合わせ（何をやっているのか？）
 # Define form actions→actionsを編集→右下ボタン
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr " XML アクションズモデルを編集"
 
 # 開発者に問い合わせ（何をやっているのか？）
 # Define form fields→fieldsを編集→右下ボタン
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr " XML アクションズフィールドを編集"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
 # 編集操作タブ内
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "エクスポート"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
 # 場所不明
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr ""
 
 # Define form actions → actionsを編集 → mailer → settings → Edit Action 'mailer'→「Header」
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "ヘッダー"
 
 # 編集操作タブ内
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "インポート"
 
 # 場所不明
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "リンクは許可されていません"
 
 # 編集操作→Saved Data→List of Save Data Adapters　 Actionでsave dataを2つ以上作ると出てくる
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "保存データアダプターのリスト"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
 # 場所不明
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "有効なEメールアドレスのリストを入力してください（カンマ区切り）"
 
 # 場所不明
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "チェックを入れてください"
 
 # 場所不明
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "チェックを外してください"
 
 # 編集操作→Saved Data→List of Save Data Adapters　アダプターがないとき
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "使用できるアダプターはありません"
 
 # 開発者に問い合わせ（何をやっているのか？）
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "上書き"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
 # actionを編集→save dataの項目のsettings
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "投稿日時"
 
 # 翻訳これでいい？
 # EasyForm を編集→「Overrides」のドロップダウンリスト内
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr " Redirect to "
 
 # EasyForm を編集→「Advanced」内Reset Button Label箱の中？
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "リセット"
 
 # 編集操作→Define form fields→fields を編集→Add new field→新しいフィールドを追加内「フィールドタイプ」リストの中？
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "リッチテキストラベル"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
 # 編集操作→「Saved data」
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "保存データ"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
 # EasyForm を編集→「Thanks Page」
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "送信完了ページ"
 
 # コントロールパネル
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "このフォームで利用できるフィールドは、以下の通りです"
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
 # 翻訳これでいい？
 # EasyForm を編集→「Overrides」のドロップダウンリスト内
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr " Traverse to "
 
 # Define form fields→fieldsを編集→フィールド〇〇を編集→Advanced内「Validators」
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "有効なデータ形式"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 # Easyform最初のページ下ボタン？
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "リセット"
 
 # Easyform最初のページ下ボタン？
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "送信"
 
 # EasyForm を編集→「Thanks Page」内Thanks summary箱の中
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "入力ありがとうございました"
 
 # EasyForm を編集→「Thanks Page」内Thanks title箱の中
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "ありがとうございました"
 
 # 開発者に問い合わせ（何をやっているのか？）
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "このフィールドを、アクションアダプターで使用するためにリクエストフォームに挿入する値としてマークします。クライアントによって変更されたり、クライアントに公開されたりすることはありません"
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 # 場所不明
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "追加ヘッダー"
 
 # 開発者に問い合わせ⑧
 # フォームが正常にバリデートされたら呼び出されるTALES式を指定します。不要な場合は空欄とします。このフィールドはフォームにあらかじめデフォルトとなる複数選択のフィールドセットのPythonスクリプトを呼び出すために一般的に使われます。この式のいかなる値も無視されます。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "フォームが正常に検証された後、アクションアダプター（存在する場合）を呼び出す前、または送信完了ページを表示する前に呼び出されるTALES式です。フォーム入力はrequest.form辞書にあります。不要な場合は空欄にしてください。このフィールドの最も一般的な使用法は、Pythonスクリプトを呼び出してフォーム入力をクリーンアップするか、代替アクションをスクリプト化することです。式によって返される値はすべて無視されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）⑦
 # フォームを表示する時に呼び出されるTALES式を指定します。不要な場合は空欄とします。このフィールドはフォームに予めデフォルトとなる複数選択のフィールドセットのPythonスクリプトを呼び出すために一般的に使われます。この式のいかなる値も無視されます。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "フォームが表示されたときに呼び出されるTALES式です。不要な場合は空欄にしてください。このフィールドの最も一般的な使用法は、request.formを事前入力することにより、複数のフィールドのデフォルトを設定するPythonスクリプトを呼び出すことです。式によって返される値はすべて無視されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
+
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）
 # actions を編集→MailerのSettings→Overridesタブ
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "BCCリストに入力された値を上書きするために評価されるTALES式です。リクエストからの未検証のデータを使用しないよう、特に注意してください。不要な場合は空欄にしてください。式は文字列のシーケンスとして評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）
 # actions を編集→MailerのSettings→Overridesタブ
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "CCリストに入力された値を上書きするために評価されるTALES式です。リクエストからの未検証のデータを使用しないよう、特に注意してください。不要な場合は空欄にしてください。式は文字列のシーケンスとして評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyForm を編集→「Advanced」内CSRF Protection説明
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "CSRF（リクエスト強要からの）保護を利用するには、ここにチェックしてください。HTTPポストアクション以外では利用できないことに注意してください"
 
 # EasyForm を編集→「Advanced」内Custom Default Fieldset Label説明
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "このフィールドではデフォルトフィールドセットラベルが変更できます"
 
 # EasyForm を編集→「基本」内Form Epilogue説明
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "このテキストは、入力フィールドの後に表示されます"
 
@@ -396,23 +400,23 @@ msgstr "このテキストは、入力フィールドの後に表示されます
 # このアクションを実行するかどうかを決定するときに評価されるTALES式です。必要のないときは空欄にします。真偽値として評価しアクションを実行するときは真が戻り値でなければなりません。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 # actionを編集⇒Overrides→Execution Conditionの説明
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "このアクションを実行するかどうかを決定するために評価されるTALES式です。不要な場合は空欄にしておくと、アクションが実行されます。式はブール値として評価されます。アクションを実行する場合はTrueを返してください。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 英語原文なし
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 # EasyForm を編集→「Advanced」内Force SSL connection説明
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "非SSLURL（http：//）経由でアクセスした場合、フォームをSSL対応バージョン（https：//）にリダイレクトするには、これをチェックしてください。正しく機能させるためには、ポート443でHTTPSプロトコルを処理し、それをZopeに転送するように構成されたWebサーバーが必要となります"
 
 # 英語原文なし　場所も不明
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
@@ -420,91 +424,91 @@ msgstr ""
 # このフィールドはフォームのアクション属性をフォームの中身をポストする先のURLを指定したもので上書きします。フォームのバリデーション、正常終了時のアクションと完了ページの処理をパスします
 # fieldsを編集→Overrides→Custom Form Action説明
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "このフィールドを使用して、フォームアクション属性をここに書かれたURLで上書きします。フォームの投稿先URLをポストします。これにより、フォームのバリデーション、成功アクションのアダプター、そして送信完了ページが実行されなくなります"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→Headers内Additional Headers説明
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "追加のEメールヘッダー行です。RFC822準拠の形式のみ使用できます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→adressing内BCC Recipients説明
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "ブラインドカーボンコピー（BCC）で送信されるEメールアドレスです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Body (signature)説明
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "フッターとして、本文から点線で区切られた下部に表示されるテキストです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Body (appended)説明
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "メール本文に表示されるフィールドの後に付加されるテキストです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Body (prepended)説明
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "メール本文に表示されるフィールドの前に付加されるテキストです"
 
 # actionsを編集→mailerのsettings→テンプレート→Mail-Body Templateの説明
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "メール本文の表示用のZopeページテンプレートです。変更する必要はありませんが、TAL（ Zopeの Template Attribute Language ）を知っている場合は、送信メールを完全にカスタマイズできます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→テンプレート内Mail Format説明
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "メール本文のMIMEタイプを設定してください。この設定は、自分が何をしているのか理解している場合にのみ変更してください。デフォルトの振る舞いを保持するには、空欄にしておいてください"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→adressing内CC Recipients
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "カーボンコピー（CC）で送信されるEメールアドレスです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→Default内Recipient's e-mail address説明
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "受信者のEメールアドレスです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→Default内Recipient's full name説明
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "メール受信者のフルネームです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→addressing内Extract Reply-To From説明
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "返信先として抽出するフィールドを選択してください。注意：指定されたフィールドがEメールアドレスであることを検証する機能をアクティブにする必要があります"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内 Subject説明
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "メッセージの件名です。件名のフィールドを規定していない場合、もしくはフィールドが空欄である場合に使われます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Extract Subject From説明
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "メールの件名として抽出したいフィールドを選択してください"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→adressingの一番上
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "宛先として抽出したいフィールドを選択してください。「値なし」以外を選択すると、上記の受信者のEメールアドレスに置き換えられます。許可されていないユーザーの入力を認める場合は、十分に注意してください"
 
@@ -512,52 +516,52 @@ msgstr "宛先として抽出したいフィールドを選択してください
 # この上書きフィールドはXHTMLの先頭にコンテンツを挿入することを許可します。これはカスタムCSSやJavaScriptを加えたいときに使用します。TALES式の戻り値を指定ください。文字列はそのまま挿入されます。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 # Easyformを編集→Overrides→Header Injectionの説明文
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "xhtmlヘッドにコンテンツを挿入するための上書きフィールドです。典型的な使い方は、カスタムCSSまたはJavaScriptを追加することです。文字列を返すTALES式を記述します。文字列は解釈（インタープリテーション？）なしで挿入されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # Define form fields→fieldsを編集→フィールド〇〇を編集→Advanced内「Hidden」
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "チェックを入れるとフィールドが非表示になります"
 
 # EasyForm を編集→「Thanks Page」内include Empties説明
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "空欄で送信された項目のタイトルを表示する際は、ここにチェックを入れてください。空欄の項目を表示しない場合は、チェックを外してください"
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Include All Fields説明
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "すべての入力されたフィールド（件名とファイル以外）を含めるには、ここにチェックしてください。チェックした場合、下のボックス内での選択は無視されます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Show Responses説明
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "メールに含めたい入力データのフィールドを選択してください"
 
 # 英語原文なし
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 # EasyForm を編集→「基本」内Form Prologue説明
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "このテキストは入力フィールドの前に表示されます"
 
@@ -565,573 +569,578 @@ msgstr "このテキストは入力フィールドの前に表示されます"
 # メールのメール受取人欄に入力された値で置き換えるために評価されるTALES式です。この目的でバリデートされていないデータを要求することは強く警告されます。必要のないときは空欄にします。文字列として評価されます。【註記】この式のエラーはフォーム表示のエラーとして表示されます
 # actionを編集→Overrides→Recipient Expressionの説明文
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "受信者のEメールアドレスに入力された値を上書きするために評価されるTALES式です。この目的でリクエストからの未検証のデータを使用しないよう、特に注意してください。不要な場合は空欄にしてください。式は文字列として評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 英語原文なし
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 # Define form actions→actionsを編集→Saved Data→settings→Default内Send Extra Data説明
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "入力内容の後ろに追加で保存したいデータをいくつでも選択してください"
 
 # Define form actions→actionsを編集→Saved Data→settings→Default内Saved Fields説明
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "保存するデータに含めたいフィールドを選択してください。空欄の場合には、全てのフィールドが保存されます"
 
 # アクションの中→custom script
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "スクリプトをここに記入してください"
 
 # Define form actions→actionsを編集→custom scriptを選択→settings→Edit Action 〇〇→Proxy role説明
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "スクリプトを実行するロールを選択してください"
 
 # Send CSV data attachment説明
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "フォームに入力された値を含むCSVファイルを添付して送信する場合は、ここにチェックを入れてください"
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Send XML data attachment説明
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "フォームに入力された値を含むXMLファイルを添付して送信する場合は、ここにチェックを入れてください"
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）②
 # From欄を置き換えるために評価されるTALES式です。必要ないときは空欄にします。文字列として評価されます。【註記】この式のエラーはフォーム表示のエラーとして表示されます
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr " \"From\" ヘッダーを上書きするために評価されるTALES式です。不要な場合は空欄にしてください。式は文字列のシーケンスとして評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyFormを編集→「Thanks Page」内Show All Fields説明
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "すべての入力されたフィールド（件名とファイル以外）をブラウザ上で再表示する場合は、ここにチェックを入れてください。チェックした場合、下のボックス内での選択は無視されます"
 
 # 英語原文なし　場所も不明
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 # EasyForm を編集→「基本」内Show Responses説明
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "送信完了ページにおいて表示したい回答内容を選択します"
 
 # actions を編集⇒MailerのSettings⇒Overrides⇒Subject Expression
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "メールの件名ヘッダーに入力されている値に対して上書きするために評価されるTALES式。不要な場合は空欄にしてください。この式は文字列として評価されます。注意：このデータ式の読み込み評価に不具合があるがエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyFormを編集⇒Advancedタブ(Submit Button Labelのヘルプ文？表示されてない・・)
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 # EasyFormを編集⇒Overridesタブ⇒Custom Submit Button Labelの説明文
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "送信ボタンのラベルを変えるための上書きフィールドです。典型的な使い方は、リクエストパラメーターでラベルを設定することです。文字列を返すTALES式を記述します。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # fieldsを編集⇒Overridesタブ⇒Default Expression
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "フィールドのデフォルトの値を取得するために、フォームが表示されたときに評価されるTALES式。不要な場合は空欄にしてください。この式は文字列として評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # fieldsを編集⇒Overridesタブ⇒Enabling Expression
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "フィールドが有効かどうかを決定するために、フォームが表示されたときに評価されるTALES式。この式はフォームにフィールドが含まれている場合にはTrue、フィールドが含まれていない場合にはFalseと評価されます。不要な場合は空欄にしてください（その場合フィールドは含まれます）。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyForm を編集⇒Thanks Pageタブ　Thanks summaryの注意書き
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "送信完了ページのタイトル下に表示されます"
 
 # EasyForm を編集⇒Thanks Pageタブ　Thanks Epilogueの注意書き
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "このテキストは、「回答内容の表示」で選択された項目の後に表示されます"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides⇒Custom Success Action Type　もしくは　Custom Success Action
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "このフィールドを送信完了ページ指定の代わりに使用することで、アクションアダプターを呼び出した後（アクションアダプターがある場合）最終的なアクションを決定します。通常、カスタム成功テンプレートやスクリプトに使用されます。不要な場合は空欄にしてください。必要な場合は、CMFFormControllerのアクションタイプと引数を指定し、実行するアクションタイプ（例：\"redirect_to\" や \"traverse_to\"）とTALES式を記述します。 例えば、\"Redirect to\" と \"string:thanks-page\"は\"thanks-page\"へとリダイレクトされます"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides⇒Custom Success Action Type　もしくは　Custom Success Action
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "このフィールドを送信完了ページ指定の代わりに使用することで、アクションアダプターを呼び出した後（アクションアダプターがある場合）最終的なアクションを決定します。通常、カスタム成功テンプレートやスクリプトに使用されます。不要な場合は空欄にしてください。必要な場合は、CMFFormControllerのアクションタイプと引数を指定し、実行するアクションタイプ（例：\"redirect_to\" や \"traverse_to\"）とTALES式を記述します。 例えば、\"Redirect to\" と \"string:thanks-page\"は\"thanks-page\"へとリダイレクトされます"
 
 # EasyForm を編集⇒Thanks Pageタブ　Thanks Prologueの注意書き
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "このテキストは、「回答内容の表示」で選択した項目の前に表示されます"
 
 # 開発者に何を行うものなのか確認
 # fields を編集⇒Setting⇒Overrides⇒Custom Validator
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "フォームがバリデーションされたときに評価されるTALES式。”value”が含まれるフィールド入力に対してバリデーションします。適切であればFalse、不適切であれば文字列のエラーメッセージを返します。例： \"python: test(value=='eggs', False, 'input must be eggs')\\u3092指定したとき、\"eggs\"の入力が要求されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Advancedタブ　Unload protectionのヘルプ文？表示されてない・・・
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 # actionsを編集⇒Saved DataのSettings
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "入力内容をダウンロードした際、一行目にカラム名を表示しますか？"
 
 # fields を編集⇒Setting⇒Advancedタブ　Validatorsの注意書き
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "このフィールドに使用するバリデータ（データ仕様）を選んでください"
 
 # actions を編集⇒MailerのSettings⇒Headersタブ
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr " HTTP ヘッダーから、メッセージに X- ヘッダーとして挿入したい項目を選択します"
 
 # 左の黒いバーの編集操作
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "インポート"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "バリデーション後のスクリプト"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "フォームセットアップスクリプト"
+
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCCの表示"
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CCの表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr " CSRF（リクエスト強要からの）保護"
 
 # actions を編集
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "カスタムスクリプト"
 
 # 開発者に何を行うものなのか確認
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "デフォルトフィールドセットラベルのカスタム"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "ダウンロードフォーマット"
 
 # EasyForm を編集⇒基本タブ
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "入力フォームの後書き"
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒Settings⇒Overrides
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "実行条件"
 
 # fields を編集⇒Settings⇒Advancedタブ
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "フィールドウィジェット（入力欄の形式）"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "SSL接続を必ず適用"
 
 # 開発者に何を行うものなのか確認
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "フィールドセットをタブに変える"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overridesタブ
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "フォームアクションのカスタム"
 
 # 値を入れるとエラーになります
 # actions を編集⇒MailerのSettings⇒Headersタブ
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "追加のヘッダー"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC受信者"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "本文（署名）"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "本文（後付加文）"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "本文（前付加文）"
 
 # actions を編集⇒MailerのSettings⇒テンプレート
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "メール本文のテンプレート"
 
 # actions を編集⇒MailerのSettings⇒テンプレートタブ
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "メールフォーマット"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC受信者"
 
 # actions を編集⇒MailerのSettings⇒Defaultタブ
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "受信者のEメールアドレス"
 
 # actions を編集⇒MailerのSettings⇒Defaultタブ
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "受信者のフルネーム"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "返信先の抽出"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "件名"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "件名の抽出"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "受信者の抽出"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 # 開発者に問い合わせ
 # EasyFormを編集⇒Overridesタブ⇒Custom Submit Button Labelの説明文
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "ヘッダーインジェクション"
 
 # fields を編集⇒Advanced
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "非表示"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "空欄で送信された項目を含める"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "ラベル"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "空欄で送信された項目を含める"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "全てのフィールドを含める"
 
 # actions を編集⇒Add new action⇒Mailer　作成後のラベル名？
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr "メーラー"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "回答内容の表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "フォームメソッド"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr "私はロボットではありません"
 
 # EasyForm を編集⇒基本タブ
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "フォームの前書き"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr "リキャプチャ"
 
 # 開発者に問い合わせ
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "受信者の表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "リセットボタンのラベル"
 
 # fields を編集⇒Setting⇒Advancedタブ　フォームタイプRich Labelのとき
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "リッチテキストラベル"
 
 # actions を編集⇒Save Dataのラベル
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "データ保存"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "追加データ"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "保存するフィールド"
 
 # actions を編集⇒ScriptのSettings
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "スクリプト本文"
 
 # actions を編集⇒ScriptのSettings
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "プロキシロール"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "CSVデータを添付ファイルで送信"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "XMLデータを添付ファイルで送信"
 
 # 開発者に問い合わせ
 # actions を編集⇒MailerのSettings⇒Overrides⇒Subject Expression
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "送信者の表示"
 
 # 開発者に問い合わせ
 # fieldsを編集⇒Overridesタブ
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "サーバーサイドの変数"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "全ての送信された内容をブラウザ上で再表示する"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "リセットボタンを表示する"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "回答内容の表示"
 
 # 開発者に問い合わせ
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "件名の表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "送信ボタンのラベル"
 
 # 開発者に問い合わせ
 # EasyForm を編集⇒Overrides
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "送信ボタンラベルのカスタム"
 
 # 開発者に問い合わせ
 # fields を編集⇒Settings⇒Overrides
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "デフォルト値の表示"
 
@@ -1139,107 +1148,107 @@ msgstr "デフォルト値の表示"
 # 開発者に問い合わせ
 # fields を編集⇒Settings⇒Overrides
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "表現を有効にする"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "送信完了ページの概要"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "送信完了ページの後書き"
 
 # 開発者に問い合わせ
 # Easyformを編集⇒Settings⇒Overrides
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "成功アクションのカスタム"
 
 # 開発者に問い合わせ
 # fields を編集⇒Settings⇒Overrides
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "成功アクションタイプのカスタム"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "送信完了ページの前書き"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "送信完了ページのタイトル"
 
 # 開発者に問い合わせ
 # fields を編集⇒Setting⇒Overrides
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "バリデータのカスタム"
 
 # 開発者に問い合わせ
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "アンロード保護"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "列名を含める"
 
 # actions を編集⇒MailerのSettings⇒Headersタブ
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTPヘッダー"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "このファイル形式は許可されていません"
 
 # 何らかのファイル容量が大きすぎるときのエラー？
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "ファイルサイズが大きすぎます"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 # actionsを編集⇒Save DataのSettings⇒Download Format？
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "カンマ区切り"
 
 # actionsを編集⇒Save DataのSettings
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "投稿日時"
 
 # actionsを編集⇒Save DataのSettings⇒Download Format？
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "タブ区切り"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/ja/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/ja/LC_MESSAGES/collective.easyform.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2021-03-31 11:45 +0900\n"
 "Last-Translator: Manabu TERADA <terada@cmscom.jp>\n"
 "Language-Team: None\n"
@@ -21,378 +21,378 @@ msgstr ""
 "Domain: collective.easyform\n"
 
 # 編集操作→Saved Data→Choose an adapterで選択→「〇 input(s) saved」
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items}件保存されています"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
 # Define form actions→「アクションを編集」→Add new action→「Action type」
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "アクションタイプ"
 
 # 場所不明
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "アクションモデル"
 
 # Define form actions→「アクションを編集」右上ボタン
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "新規アクションを追加"
 
 # Define form actions → actionsを編集→ mailer → settings → Edit Action 'mailer’→ addressing
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "アドレス指定"
 
 # EasyForm を編集→「Advanced」など
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr "上級者向け設定"
 
 # コントロールパネル内
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "追加許可フィールド"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
 # セーブデータ内　アダプターが存在するとき
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "アダプターを選択してください"
 
 # セーブデータ内など
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "全件削除"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
 # 編集操作→Define form actions
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "アクションの定義"
 
 # 編集操作→Define form fields
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "フィールドの定義"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
 # 授業内フォルダ→新規追加→Easyform
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
 # Define form actions→「actionsを編集」
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "‘${fieldname}‘のアクションを編集"
 
 # 開発者に問い合わせ（何をやっているのか？）
 # Define form actions→actionsを編集→右下ボタン
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr " XML アクションズモデルを編集"
 
 # 開発者に問い合わせ（何をやっているのか？）
 # Define form fields→fieldsを編集→右下ボタン
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr " XML アクションズフィールドを編集"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
 # 編集操作タブ内
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "エクスポート"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
 # 場所不明
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr ""
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr ""
 
 # Define form actions → actionsを編集 → mailer → settings → Edit Action 'mailer'→「Header」
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "ヘッダー"
 
 # 編集操作タブ内
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "インポート"
 
 # 場所不明
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "リンクは許可されていません"
 
 # 編集操作→Saved Data→List of Save Data Adapters　 Actionでsave dataを2つ以上作ると出てくる
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "保存データアダプターのリスト"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
 # 場所不明
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "有効なEメールアドレスのリストを入力してください（カンマ区切り）"
 
 # 場所不明
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "チェックを入れてください"
 
 # 場所不明
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "チェックを外してください"
 
 # 編集操作→Saved Data→List of Save Data Adapters　アダプターがないとき
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "使用できるアダプターはありません"
 
 # 開発者に問い合わせ（何をやっているのか？）
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "上書き"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
 # actionを編集→save dataの項目のsettings
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "投稿日時"
 
 # 翻訳これでいい？
 # EasyForm を編集→「Overrides」のドロップダウンリスト内
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr " Redirect to "
 
 # EasyForm を編集→「Advanced」内Reset Button Label箱の中？
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "リセット"
 
 # 編集操作→Define form fields→fields を編集→Add new field→新しいフィールドを追加内「フィールドタイプ」リストの中？
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "リッチテキストラベル"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
 # 編集操作→「Saved data」
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "保存データ"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
 # EasyForm を編集→「Thanks Page」
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "送信完了ページ"
 
 # コントロールパネル
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "このフォームで利用できるフィールドは、以下の通りです"
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
 # 翻訳これでいい？
 # EasyForm を編集→「Overrides」のドロップダウンリスト内
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr " Traverse to "
 
 # Define form fields→fieldsを編集→フィールド〇〇を編集→Advanced内「Validators」
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "有効なデータ形式"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 # Easyform最初のページ下ボタン？
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "リセット"
 
 # Easyform最初のページ下ボタン？
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "送信"
 
 # EasyForm を編集→「Thanks Page」内Thanks summary箱の中
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "入力ありがとうございました"
 
 # EasyForm を編集→「Thanks Page」内Thanks title箱の中
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "ありがとうございました"
 
 # 開発者に問い合わせ（何をやっているのか？）
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "このフィールドを、アクションアダプターで使用するためにリクエストフォームに挿入する値としてマークします。クライアントによって変更されたり、クライアントに公開されたりすることはありません"
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 # 場所不明
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "追加ヘッダー"
 
 # 開発者に問い合わせ⑧
 # フォームが正常にバリデートされたら呼び出されるTALES式を指定します。不要な場合は空欄とします。このフィールドはフォームにあらかじめデフォルトとなる複数選択のフィールドセットのPythonスクリプトを呼び出すために一般的に使われます。この式のいかなる値も無視されます。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "フォームが正常に検証された後、アクションアダプター（存在する場合）を呼び出す前、または送信完了ページを表示する前に呼び出されるTALES式です。フォーム入力はrequest.form辞書にあります。不要な場合は空欄にしてください。このフィールドの最も一般的な使用法は、Pythonスクリプトを呼び出してフォーム入力をクリーンアップするか、代替アクションをスクリプト化することです。式によって返される値はすべて無視されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）⑦
 # フォームを表示する時に呼び出されるTALES式を指定します。不要な場合は空欄とします。このフィールドはフォームに予めデフォルトとなる複数選択のフィールドセットのPythonスクリプトを呼び出すために一般的に使われます。この式のいかなる値も無視されます。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "フォームが表示されたときに呼び出されるTALES式です。不要な場合は空欄にしてください。このフィールドの最も一般的な使用法は、request.formを事前入力することにより、複数のフィールドのデフォルトを設定するPythonスクリプトを呼び出すことです。式によって返される値はすべて無視されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）
 # actions を編集→MailerのSettings→Overridesタブ
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "BCCリストに入力された値を上書きするために評価されるTALES式です。リクエストからの未検証のデータを使用しないよう、特に注意してください。不要な場合は空欄にしてください。式は文字列のシーケンスとして評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）
 # actions を編集→MailerのSettings→Overridesタブ
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "CCリストに入力された値を上書きするために評価されるTALES式です。リクエストからの未検証のデータを使用しないよう、特に注意してください。不要な場合は空欄にしてください。式は文字列のシーケンスとして評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyForm を編集→「Advanced」内CSRF Protection説明
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "CSRF（リクエスト強要からの）保護を利用するには、ここにチェックしてください。HTTPポストアクション以外では利用できないことに注意してください"
 
 # EasyForm を編集→「Advanced」内Custom Default Fieldset Label説明
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "このフィールドではデフォルトフィールドセットラベルが変更できます"
 
 # EasyForm を編集→「基本」内Form Epilogue説明
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "このテキストは、入力フィールドの後に表示されます"
 
@@ -400,23 +400,23 @@ msgstr "このテキストは、入力フィールドの後に表示されます
 # このアクションを実行するかどうかを決定するときに評価されるTALES式です。必要のないときは空欄にします。真偽値として評価しアクションを実行するときは真が戻り値でなければなりません。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 # actionを編集⇒Overrides→Execution Conditionの説明
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "このアクションを実行するかどうかを決定するために評価されるTALES式です。不要な場合は空欄にしておくと、アクションが実行されます。式はブール値として評価されます。アクションを実行する場合はTrueを返してください。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 英語原文なし
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 # EasyForm を編集→「Advanced」内Force SSL connection説明
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "非SSLURL（http：//）経由でアクセスした場合、フォームをSSL対応バージョン（https：//）にリダイレクトするには、これをチェックしてください。正しく機能させるためには、ポート443でHTTPSプロトコルを処理し、それをZopeに転送するように構成されたWebサーバーが必要となります"
 
 # 英語原文なし　場所も不明
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
@@ -424,91 +424,91 @@ msgstr ""
 # このフィールドはフォームのアクション属性をフォームの中身をポストする先のURLを指定したもので上書きします。フォームのバリデーション、正常終了時のアクションと完了ページの処理をパスします
 # fieldsを編集→Overrides→Custom Form Action説明
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "このフィールドを使用して、フォームアクション属性をここに書かれたURLで上書きします。フォームの投稿先URLをポストします。これにより、フォームのバリデーション、成功アクションのアダプター、そして送信完了ページが実行されなくなります"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→Headers内Additional Headers説明
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "追加のEメールヘッダー行です。RFC822準拠の形式のみ使用できます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→adressing内BCC Recipients説明
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "ブラインドカーボンコピー（BCC）で送信されるEメールアドレスです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Body (signature)説明
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "フッターとして、本文から点線で区切られた下部に表示されるテキストです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Body (appended)説明
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "メール本文に表示されるフィールドの後に付加されるテキストです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Body (prepended)説明
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "メール本文に表示されるフィールドの前に付加されるテキストです"
 
 # actionsを編集→mailerのsettings→テンプレート→Mail-Body Templateの説明
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "メール本文の表示用のZopeページテンプレートです。変更する必要はありませんが、TAL（ Zopeの Template Attribute Language ）を知っている場合は、送信メールを完全にカスタマイズできます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→テンプレート内Mail Format説明
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "メール本文のMIMEタイプを設定してください。この設定は、自分が何をしているのか理解している場合にのみ変更してください。デフォルトの振る舞いを保持するには、空欄にしておいてください"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→adressing内CC Recipients
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "カーボンコピー（CC）で送信されるEメールアドレスです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→Default内Recipient's e-mail address説明
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "受信者のEメールアドレスです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→Default内Recipient's full name説明
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "メール受信者のフルネームです"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→addressing内Extract Reply-To From説明
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "返信先として抽出するフィールドを選択してください。注意：指定されたフィールドがEメールアドレスであることを検証する機能をアクティブにする必要があります"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内 Subject説明
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "メッセージの件名です。件名のフィールドを規定していない場合、もしくはフィールドが空欄である場合に使われます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Extract Subject From説明
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "メールの件名として抽出したいフィールドを選択してください"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→adressingの一番上
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "宛先として抽出したいフィールドを選択してください。「値なし」以外を選択すると、上記の受信者のEメールアドレスに置き換えられます。許可されていないユーザーの入力を認める場合は、十分に注意してください"
 
@@ -516,52 +516,52 @@ msgstr "宛先として抽出したいフィールドを選択してください
 # この上書きフィールドはXHTMLの先頭にコンテンツを挿入することを許可します。これはカスタムCSSやJavaScriptを加えたいときに使用します。TALES式の戻り値を指定ください。文字列はそのまま挿入されます。【註記】この式の値にあるエラーはフォーム表示のエラーとして表示されます。
 # Easyformを編集→Overrides→Header Injectionの説明文
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "xhtmlヘッドにコンテンツを挿入するための上書きフィールドです。典型的な使い方は、カスタムCSSまたはJavaScriptを追加することです。文字列を返すTALES式を記述します。文字列は解釈（インタープリテーション？）なしで挿入されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # Define form fields→fieldsを編集→フィールド〇〇を編集→Advanced内「Hidden」
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "チェックを入れるとフィールドが非表示になります"
 
 # EasyForm を編集→「Thanks Page」内include Empties説明
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "空欄で送信された項目のタイトルを表示する際は、ここにチェックを入れてください。空欄の項目を表示しない場合は、チェックを外してください"
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr ""
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Include All Fields説明
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "すべての入力されたフィールド（件名とファイル以外）を含めるには、ここにチェックしてください。チェックした場合、下のボックス内での選択は無視されます"
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Show Responses説明
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "メールに含めたい入力データのフィールドを選択してください"
 
 # 英語原文なし
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 # EasyForm を編集→「基本」内Form Prologue説明
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "このテキストは入力フィールドの前に表示されます"
 
@@ -569,578 +569,578 @@ msgstr "このテキストは入力フィールドの前に表示されます"
 # メールのメール受取人欄に入力された値で置き換えるために評価されるTALES式です。この目的でバリデートされていないデータを要求することは強く警告されます。必要のないときは空欄にします。文字列として評価されます。【註記】この式のエラーはフォーム表示のエラーとして表示されます
 # actionを編集→Overrides→Recipient Expressionの説明文
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "受信者のEメールアドレスに入力された値を上書きするために評価されるTALES式です。この目的でリクエストからの未検証のデータを使用しないよう、特に注意してください。不要な場合は空欄にしてください。式は文字列として評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 英語原文なし
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 # Define form actions→actionsを編集→Saved Data→settings→Default内Send Extra Data説明
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "入力内容の後ろに追加で保存したいデータをいくつでも選択してください"
 
 # Define form actions→actionsを編集→Saved Data→settings→Default内Saved Fields説明
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "保存するデータに含めたいフィールドを選択してください。空欄の場合には、全てのフィールドが保存されます"
 
 # アクションの中→custom script
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "スクリプトをここに記入してください"
 
 # Define form actions→actionsを編集→custom scriptを選択→settings→Edit Action 〇〇→Proxy role説明
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "スクリプトを実行するロールを選択してください"
 
 # Send CSV data attachment説明
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "フォームに入力された値を含むCSVファイルを添付して送信する場合は、ここにチェックを入れてください"
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 # Define form actions→actionsを編集→mailer→settings→Edit Action 'mailer'→メッセージ内Send XML data attachment説明
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "フォームに入力された値を含むXMLファイルを添付して送信する場合は、ここにチェックを入れてください"
 
 # 開発者に問い合わせ後、日本語訳再検討（Formgenの日本語訳）②
 # From欄を置き換えるために評価されるTALES式です。必要ないときは空欄にします。文字列として評価されます。【註記】この式のエラーはフォーム表示のエラーとして表示されます
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr " \"From\" ヘッダーを上書きするために評価されるTALES式です。不要な場合は空欄にしてください。式は文字列のシーケンスとして評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyFormを編集→「Thanks Page」内Show All Fields説明
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "すべての入力されたフィールド（件名とファイル以外）をブラウザ上で再表示する場合は、ここにチェックを入れてください。チェックした場合、下のボックス内での選択は無視されます"
 
 # 英語原文なし　場所も不明
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 # EasyForm を編集→「基本」内Show Responses説明
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "送信完了ページにおいて表示したい回答内容を選択します"
 
 # actions を編集⇒MailerのSettings⇒Overrides⇒Subject Expression
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "メールの件名ヘッダーに入力されている値に対して上書きするために評価されるTALES式。不要な場合は空欄にしてください。この式は文字列として評価されます。注意：このデータ式の読み込み評価に不具合があるがエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyFormを編集⇒Advancedタブ(Submit Button Labelのヘルプ文？表示されてない・・)
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 # EasyFormを編集⇒Overridesタブ⇒Custom Submit Button Labelの説明文
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "送信ボタンのラベルを変えるための上書きフィールドです。典型的な使い方は、リクエストパラメーターでラベルを設定することです。文字列を返すTALES式を記述します。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # fieldsを編集⇒Overridesタブ⇒Default Expression
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "フィールドのデフォルトの値を取得するために、フォームが表示されたときに評価されるTALES式。不要な場合は空欄にしてください。この式は文字列として評価されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # fieldsを編集⇒Overridesタブ⇒Enabling Expression
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "フィールドが有効かどうかを決定するために、フォームが表示されたときに評価されるTALES式。この式はフォームにフィールドが含まれている場合にはTrue、フィールドが含まれていない場合にはFalseと評価されます。不要な場合は空欄にしてください（その場合フィールドは含まれます）。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # EasyForm を編集⇒Thanks Pageタブ　Thanks summaryの注意書き
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "送信完了ページのタイトル下に表示されます"
 
 # EasyForm を編集⇒Thanks Pageタブ　Thanks Epilogueの注意書き
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "このテキストは、「回答内容の表示」で選択された項目の後に表示されます"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides⇒Custom Success Action Type　もしくは　Custom Success Action
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "このフィールドを送信完了ページ指定の代わりに使用することで、アクションアダプターを呼び出した後（アクションアダプターがある場合）最終的なアクションを決定します。通常、カスタム成功テンプレートやスクリプトに使用されます。不要な場合は空欄にしてください。必要な場合は、CMFFormControllerのアクションタイプと引数を指定し、実行するアクションタイプ（例：\"redirect_to\" や \"traverse_to\"）とTALES式を記述します。 例えば、\"Redirect to\" と \"string:thanks-page\"は\"thanks-page\"へとリダイレクトされます"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides⇒Custom Success Action Type　もしくは　Custom Success Action
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "このフィールドを送信完了ページ指定の代わりに使用することで、アクションアダプターを呼び出した後（アクションアダプターがある場合）最終的なアクションを決定します。通常、カスタム成功テンプレートやスクリプトに使用されます。不要な場合は空欄にしてください。必要な場合は、CMFFormControllerのアクションタイプと引数を指定し、実行するアクションタイプ（例：\"redirect_to\" や \"traverse_to\"）とTALES式を記述します。 例えば、\"Redirect to\" と \"string:thanks-page\"は\"thanks-page\"へとリダイレクトされます"
 
 # EasyForm を編集⇒Thanks Pageタブ　Thanks Prologueの注意書き
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "このテキストは、「回答内容の表示」で選択した項目の前に表示されます"
 
 # 開発者に何を行うものなのか確認
 # fields を編集⇒Setting⇒Overrides⇒Custom Validator
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "フォームがバリデーションされたときに評価されるTALES式。”value”が含まれるフィールド入力に対してバリデーションします。適切であればFalse、不適切であれば文字列のエラーメッセージを返します。例： \"python: test(value=='eggs', False, 'input must be eggs')\\u3092指定したとき、\"eggs\"の入力が要求されます。注意：この式の評価がエラーの場合には、フォームの表示にもエラーが生じます"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Advancedタブ　Unload protectionのヘルプ文？表示されてない・・・
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 # actionsを編集⇒Saved DataのSettings
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "入力内容をダウンロードした際、一行目にカラム名を表示しますか？"
 
 # fields を編集⇒Setting⇒Advancedタブ　Validatorsの注意書き
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "このフィールドに使用するバリデータ（データ仕様）を選んでください"
 
 # actions を編集⇒MailerのSettings⇒Headersタブ
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr " HTTP ヘッダーから、メッセージに X- ヘッダーとして挿入したい項目を選択します"
 
 # 左の黒いバーの編集操作
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "インポート"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "バリデーション後のスクリプト"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overrides
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "フォームセットアップスクリプト"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCCの表示"
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CCの表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr " CSRF（リクエスト強要からの）保護"
 
 # actions を編集
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "カスタムスクリプト"
 
 # 開発者に何を行うものなのか確認
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "デフォルトフィールドセットラベルのカスタム"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "ダウンロードフォーマット"
 
 # EasyForm を編集⇒基本タブ
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "入力フォームの後書き"
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒Settings⇒Overrides
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "実行条件"
 
 # fields を編集⇒Settings⇒Advancedタブ
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "フィールドウィジェット（入力欄の形式）"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "SSL接続を必ず適用"
 
 # 開発者に何を行うものなのか確認
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "フィールドセットをタブに変える"
 
 # 開発者に何を行うものなのか確認
 # EasyFormを編集⇒Overridesタブ
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "フォームアクションのカスタム"
 
 # 値を入れるとエラーになります
 # actions を編集⇒MailerのSettings⇒Headersタブ
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "追加のヘッダー"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC受信者"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "本文（署名）"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "本文（後付加文）"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "本文（前付加文）"
 
 # actions を編集⇒MailerのSettings⇒テンプレート
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "メール本文のテンプレート"
 
 # actions を編集⇒MailerのSettings⇒テンプレートタブ
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "メールフォーマット"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC受信者"
 
 # actions を編集⇒MailerのSettings⇒Defaultタブ
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "受信者のEメールアドレス"
 
 # actions を編集⇒MailerのSettings⇒Defaultタブ
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "受信者のフルネーム"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "返信先の抽出"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "件名"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "件名の抽出"
 
 # actions を編集⇒MailerのSettings⇒Addressingタブ
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "受信者の抽出"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 # 開発者に問い合わせ
 # EasyFormを編集⇒Overridesタブ⇒Custom Submit Button Labelの説明文
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "ヘッダーインジェクション"
 
 # fields を編集⇒Advanced
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "非表示"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "空欄で送信された項目を含める"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "ラベル"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "空欄で送信された項目を含める"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "全てのフィールドを含める"
 
 # actions を編集⇒Add new action⇒Mailer　作成後のラベル名？
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr "メーラー"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "回答内容の表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "フォームメソッド"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr "私はロボットではありません"
 
 # EasyForm を編集⇒基本タブ
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "フォームの前書き"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr "リキャプチャ"
 
 # 開発者に問い合わせ
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "受信者の表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "リセットボタンのラベル"
 
 # fields を編集⇒Setting⇒Advancedタブ　フォームタイプRich Labelのとき
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "リッチテキストラベル"
 
 # actions を編集⇒Save Dataのラベル
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "データ保存"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "追加データ"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "保存するフィールド"
 
 # actions を編集⇒ScriptのSettings
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "スクリプト本文"
 
 # actions を編集⇒ScriptのSettings
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "プロキシロール"
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "CSVデータを添付ファイルで送信"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 # actions を編集⇒MailerのSettings⇒メッセージタブ
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "XMLデータを添付ファイルで送信"
 
 # 開発者に問い合わせ
 # actions を編集⇒MailerのSettings⇒Overrides⇒Subject Expression
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "送信者の表示"
 
 # 開発者に問い合わせ
 # fieldsを編集⇒Overridesタブ
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "サーバーサイドの変数"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "全ての送信された内容をブラウザ上で再表示する"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "リセットボタンを表示する"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "回答内容の表示"
 
 # 開発者に問い合わせ
 # actions を編集⇒MailerのSettings⇒Overrides
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "件名の表示"
 
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "送信ボタンのラベル"
 
 # 開発者に問い合わせ
 # EasyForm を編集⇒Overrides
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "送信ボタンラベルのカスタム"
 
 # 開発者に問い合わせ
 # fields を編集⇒Settings⇒Overrides
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "デフォルト値の表示"
 
@@ -1148,107 +1148,107 @@ msgstr "デフォルト値の表示"
 # 開発者に問い合わせ
 # fields を編集⇒Settings⇒Overrides
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "表現を有効にする"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "送信完了ページの概要"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "送信完了ページの後書き"
 
 # 開発者に問い合わせ
 # Easyformを編集⇒Settings⇒Overrides
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "成功アクションのカスタム"
 
 # 開発者に問い合わせ
 # fields を編集⇒Settings⇒Overrides
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "成功アクションタイプのカスタム"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "送信完了ページの前書き"
 
 # EasyForm を編集⇒Thanks Pageタブ
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "送信完了ページのタイトル"
 
 # 開発者に問い合わせ
 # fields を編集⇒Setting⇒Overrides
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "バリデータのカスタム"
 
 # 開発者に問い合わせ
 # EasyForm を編集⇒Advancedタブ
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "アンロード保護"
 
 # actions を編集⇒Save DataのSettings
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "列名を含める"
 
 # actions を編集⇒MailerのSettings⇒Headersタブ
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTPヘッダー"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "このファイル形式は許可されていません"
 
 # 何らかのファイル容量が大きすぎるときのエラー？
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "ファイルサイズが大きすぎます"
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 # actionsを編集⇒Save DataのSettings⇒Download Format？
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "カンマ区切り"
 
 # actionsを編集⇒Save DataのSettings
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "投稿日時"
 
 # actionsを編集⇒Save DataのSettings⇒Download Format？
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "タブ区切り"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/nl/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/nl/LC_MESSAGES/collective.easyform.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone 5-buildout\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2021-06-02 16:11+0200\n"
 "Last-Translator: Thibaut Born <thibaut.born@kuleuven.be>\n"
 "Language-Team: Dutch\n"
@@ -18,1010 +18,1019 @@ msgstr ""
 "Domain: collective.easyform\n"
 "Language: nl\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} invoer(en) opgeslagen"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Type actie"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Actiemodel"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Voeg nieuwe actie toe"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Adressering"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Toegestane velden"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "CSV-scheidingsteken"
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Kies een adapter"
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Wis alles"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Formulieracties bewerken"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Formuliervelden bewerken"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Bewerk '${fieldname}' actie"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Bewerk XML actiemodel"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Bewerk XML veldenmodel"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Exporteer"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Veldenmodel"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr "Limiet voor bestandsgrootte"
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulier geïmporteerd"
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Importeer"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Links zijn niet toegelaten"
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Lijst van gegevensopslag adapters"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Moet een geldige lijst van e-mailadressen zijn (gescheiden door comma's"
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Moet worden geselecteerd"
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Mag niet geselecteerd zijn"
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Geen adapters beschikbaar"
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr "Mogelijke antwoorden"
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr "Mogelijke vragen"
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Datum/tijd van verzending"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Omleiden naar"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Label met opmaak"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr "opslaan"
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr "Opslag"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Opslag"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Stel het standaardscheidingsteken in voor CSV-downloads"
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr "Maximale grootte (in bytes) voor bestanden die kunnen worden opgeladen"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "'Bedankt' pagina"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Deze velden zijn beschikbaar voor het formulier"
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traverseren naar"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Jouw e-mailadres"
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Verzend"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Bedankt voor je bijdrage"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Bedankt"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Markeer dit veld als een waarde die in het request formulier geïnjecteerd wordt voor gebruik door acties en die niet te wijzigen is door of zichtbaar is voor de gebruiker."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Een TALES-expressie die zal worden aangeroepen nadat de validatie van het formulier is geslaagd, maar voordat de actie (indien ingesteld) wordt aangeroepen of een 'bedankt' pagina wordt getoond. Formulierinvoer zal worden getoond in request.form 'dictionary'. Indien niet nodig, leeglaten. Meestal wordt dit veld gebruikt om een python-script aan te roepen om de formulierinvoer te wissen of een alternatieve actie te scripten. Elke waarde die door de expressie wordt teruggegeven zal worden genegeerd. MERK OP: fouten in de evaluatie van deze expressie resulteren in een fout bij het tonen van het formulier."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Een TALES-expressie die wordt aangeroepen als het formulier wordt getoond. Laat leeg indien dit niet nodig is. Het is gebruikelijk om dit veld een python-script te laten aanroepen dat alvast standaardwaarden instelt voor meerdere velden via request.form. Elke waarde die door deze expressie wordt teruggeven zal worden genegeerd. MERK OP: fouten in de evaluatie van deze expressie resulteren in een fout bij het tonen van het formulier."
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Een TALES expressie die gebruikt wordt om de waarde van de BCC adreslijst (blinde kopie) te overschrijven. We raden sterk af om niet gevalideerde data uit het request hiervoor te gebruiken. Laat leeg indien dit niet nodig is. De expressie moet een 'string' terug geven. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Een TALES expressie die gebruikt wordt om de waarde van de CC adreslijst (blinde kopie) te overschrijven. We raden sterk af om niet gevalideerde data uit het request hiervoor te gebruiken. Laat leeg indien dit niet nodig is. De expressie moet een 'string' terug geven. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Selecteer dit om Cross-Site Request Forgery aan te zetten. Let op dat alleen HTTP POST acties worden toegestaan."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Dit veld maakt het mogelijk om het standaard fieldset-label te wijzigen"
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Deze tekst zal worden getoond onder de velden van het formulier."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Een TALES-expressie die zal worden geëvalueerd om te bepalen of deze actie moet worden uitgevoerd of niet. Laat leeg indien dit niet nodig is en de actie wordt uitgevoerd."
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Vink dit aan om het formulier om te leiden naar een SSL-ingeschakelde versie van zichzelf (https://) als het wordt geopend via een niet-SSL-URL (http://). Om goed te kunnen functioneren, is een webserver nodig die is geconfigureerd om het HTTPS-protocol op poort 443 af te handelen en door te sturen naar Zope."
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Gebruik dit veld om het actie attribuut van het formulier te overschrijven. Geef een URL op waarnaar gepost zal worden. Dit zal buiten de validatie, succesactie-adapter en 'Bedankt' pagina om gebeuren."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Additionele e-mail headers. Gebruik alleen RFC822-compatible headers."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "E-mailadressen die een BCC zullen ontvangen."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Tekst die als voetnoot gebruikt zal worden, gescheiden van de hoofdtekst met een gestreepte lijn."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Tekst die achter de velden in de tekst van de e-mail wordt geplakt."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Tekst die voor de genoemde velden in het E-mailhoofdtekst wordt geplakt."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Dit is een Zope Page Template die gebruikt wordt voor de weergave van de tekst van de e-mail. Het is niet nodig dit aan te passen, maar als u TAL kent (de Template Attribute Language van Zope) heeft u de volledige controle over de lay-out van de uitgaande e-mails."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Stel het MIME-type in van de e-mailtekst. Verander deze instelling alleen als u exact weet wat u aan het doen bent. Leeg laten voor standaard gedrag."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "E-mailadressen van de CC-ontvangers."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Het e-mailadres van de geadresseerde."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "De volledige naam van de ontvanger van het verstuurde formulier."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Kies een formulierveld waarvan u de invoer wilt extraheren voor de 'Reply-To' header. MERK OP: U moet e-mailadresverificatie activeren voor het desbetreffende veld."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Onderwerpregel van het bericht. Dit wordt gebruikt als u niet een onderwerpveld aangeeft of als het veld leeg is."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Kies een formulierveld vanwaar u de invoer wilt extraheren voor de onderwerpregel van de e-mail."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Kies een formulierveld vanwaar u invoer wilt extraheren voor de \"Aan\" header. Als u iets anders kiest dan \"None\" zal deze het \"Ontvanger e-mailadres\" instelling van hierboven overschrijven. Wees erg voorzichtig met het toestaan van niet gecontroleerde input van gebruikers voor dit doel (om spam tegen te gaan)."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Dit overschrijfveld biedt u de mogelijkheid om inhoud in de xhtml-head toe te voegen. Typisch gebruik hiervan is voor maatwerk CSS of JavaScript. Geef een TALES-expressie op die een 'string' terug geeft. Deze 'string' zal zonder interpretatie worden ingevoegd. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Veld is verborgen"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Schakel deze optie in om titels van lege velden te tonen. Indien uitgeschakeld zullen lege velden niet getoond worden."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Schakel deze optie in om titels van lege velden te tonen. Indien uitgeschakeld zullen lege velden niet getoond worden."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Schakel deze optie in om alle velden te tonen (beehalve label en bestand velden). Indien ingeschakeld zullen de keuzes uit onderstaande keuzeveld genegeerd worden."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Kies de velden waarvan u de invoer in de e-mail wilt opnemen."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Deze tekst zal worden getoond boven de velden van het formulier."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Een TALES expressie die gebruikt wordt om de waarde van het e-mailadres van de afzender te overschrijven. We raden sterk af om niet gevalideerde data uit het request hiervoor te gebruiken. Laat leeg indien dit niet nodig is. De expressie moet een 'string' terug geven. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Selecteer welke extra gegevens u wilt opslaan bij het formulier."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Selecteer hier welke velden moeten worden opgeslagen. Indien leeg, worden alle invoer opgeslagen. "
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Schrijf hier uw script."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rol waarmee dit script wordt uitgevoerd."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Selecteer dit om een ​​CSV-bestandsbijlage te verzenden met de waarden die in het formulier zijn ingevuld. "
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Selecteer dit om een ​​XML-bestandsbijlage te verzenden met de waarden die in het formulier zijn ingevuld."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden om het \"Van\" veld te overschrijven. Laat leeg indien dit niet nodig is. De expressie moet een 'string' opleveren. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Selecteer dit om de gegevens van alle velden te tonen (behalve de label- en bestandsvelden). Als u dit selecteert worden de keuzes in de selectiebox hieronder genegeerd."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Selecteer de velden waarvan u de gegevens wilt tonen op de succespagina."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden om elke andere waarde van de onderwerp header te overschrijven. Laat leeg indien dit niet nodig is. De expressie moet een 'string' opleveren. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier"
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Dit overschrijfveld biedt u de mogelijkheid om de tekst voor de verzendknop aan te passen. Typisch wordt dit label ingesteld met verzoekparameters. Geef een TALES-expressie op die een 'string' terug geeft. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden als het formulier wordt getoond om de standaardwaarde van het veld te verkrijgen. Laat leeg indien dit niet nodig is. De expressie moet een 'string' opleveren. MERK OP: fouten in de validatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden wanneer het formulier getoond wordt, om te bepalen of het veld aan staat. De expressie moet een 'True' waarde opleveren wanneer het veld op het formulier moet staan en 'False' wanneer het kan worden weggelaten. Laat leeg indien dit niet nodig is: het veld zal dan worden opgenomen in het formulier. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Wordt in de 'bedankt'-pagina gebruikt."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Deze tekst zal onder de ingevulde gegevens worden getoond."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Gebruik dit veld in plaats van een 'Bedankt' pagina, om de laatste actie te bepalen na het aanroepen van de formulieractie (indien u deze heeft geselecteerd). Normaal gesproken zou u hiervoor een aangepast 'geslaagd' sjabloon of script gebruiken. Laat leeg als het niet nodig is. Anders invullen alsof u een 'CMFFormController' actie type en argument zou opgeven, compleet met het type actie dat moet worden uitgevoerd (bv. \"redirect_to\" of \"traverse_to\") en een TALES-expressie. Bijvoorbeeld, \"redirect_to:string:thanks-page\" zal u doorsturen naar 'thanks-page'."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Gebruik dit veld in plaats van een 'Bedankt' pagina, om de laatste actie te bepalen na het aanroepen van de formulieractie (indien u deze heeft geselecteerd). Normaal gesproken zou u hiervoor een aangepast 'geslaagd' sjabloon of script gebruiken. Laat leeg als het niet nodig is. Anders invullen alsof u een 'CMFFormController' actie type en argument zou opgeven, compleet met het type actie dat moet worden uitgevoerd (bv. \"redirect_to\" of \"traverse_to\") en een TALES-expressie. Bijvoorbeeld, \"redirect_to:string:thanks-page\" zal u doorsturen naar 'thanks-page'."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Deze tekst zal boven de ingevulde gegevens worden getoond."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Een TALES-expressie die wordt geëvalueerd als het formulier wordt gevalideerd. Validatie is tegen 'value' welke de formulierinvoer zal bevatten. Geeft 'False' terug indien valide; indien niet valide wordt een 'string' met foutmelding teruggegeven. Voorbeeld: \"python: test(value=='eieren', False, 'invoer moet eieren zijn')\" stelt \"eieren\" als verplichte invoer. MERK OP: fouten in deze expressie zullen resulteren in een fout bij het weergeven van het formulier."
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Kolomnamen tonen"
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Selecteer de validators voor dit veld"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Selecteer welke HTTP Headers u als extra headers wilt invoegen in het bericht."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "importeer"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script na validatie"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Formulier opstart script"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCC expressie"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CC Expressie"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "CSRF beveiliging"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "Aangepast script"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Eigen standaard Fieldset-label"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Download formaat"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Formulier nawoord"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Conditie"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Veldwidget"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "SSL-verbinding forceren"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Zet fieldsets om in tabbladen"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Maatwerkformulieractie"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Additionele Headers"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC-ontvangers"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Hoofdtekst (ondertekening)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Hoofdtekst (achteraan geplakt)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Hoofdtekst (Proloog)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Sjabloon voor hoofdtekst van email"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "E-mail hoofdtekst type"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC geadresseerden"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "E-mailadres van geadresseerde"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Naam van geadresseerde"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Gebruik Reply-To van"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Onderwerp"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Gebruik onderwerp van"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Gebruik ontvanger van"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Header Injectie"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Verborgen"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Velden met lege waarden toevoegen"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Velden met lege waarden toevoegen"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Alle velden toevoegen"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Toon ingevulde gegevens"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Formulier methode"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Formulier voorwoord"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Geadresseerde expressie"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Label resetknop"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Label met opmaak"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "Opslag"
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Opgeslagen velden"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script inhoud"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy rol"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "CSV-gegevensbijlage verzenden"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "XML-gegevensbijlage verzenden"
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Afzender expressie"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Server-Side Variabele"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Toon alle velden"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Toon knop 'Wissen'"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Toon ingevulde gegevens"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Onderwerp expressie"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Tekst voor knop verzenden"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Tekst voor eigen verzendknop"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Standaard expressie"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Ingeschakelde expressie"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "'Bedankt' samenvatting"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "'Bedankt' nawoord"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Aangepaste succesactie"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Type van aangepaste succesactie"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "'Bedankt' voorwoord"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "'Bedankt' titel"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Aangepaste validatie"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Bescherming lossen"
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Kolomnamen opnemen"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Het bestandstype ${ftype} is niet toegestaan ​​als upload"
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Het geüploade bestand is groter dan ${size} bytes."
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Door komma's gescheiden waarden (CSV)"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Datum en tijd waarop het formulier is verzonden"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Door tabs gescheiden waarden (TSV)"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/nl/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/nl/LC_MESSAGES/collective.easyform.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone 5-buildout\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2021-06-02 16:11+0200\n"
 "Last-Translator: Thibaut Born <thibaut.born@kuleuven.be>\n"
 "Language-Team: Dutch\n"
@@ -18,1019 +18,1019 @@ msgstr ""
 "Domain: collective.easyform\n"
 "Language: nl\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} invoer(en) opgeslagen"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Type actie"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Actiemodel"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Voeg nieuwe actie toe"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Adressering"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Toegestane velden"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr "CSV-scheidingsteken"
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr "Kies een adapter"
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Wis alles"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Formulieracties bewerken"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Formuliervelden bewerken"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr ""
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Bewerk '${fieldname}' actie"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Bewerk XML actiemodel"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Bewerk XML veldenmodel"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Exporteer"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Veldenmodel"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr "Limiet voor bestandsgrootte"
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulier geïmporteerd"
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Importeer"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Links zijn niet toegelaten"
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr "Lijst van gegevensopslag adapters"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Moet een geldige lijst van e-mailadressen zijn (gescheiden door comma's"
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Moet worden geselecteerd"
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Mag niet geselecteerd zijn"
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr "Geen adapters beschikbaar"
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr ""
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr "Mogelijke antwoorden"
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr "Mogelijke vragen"
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Datum/tijd van verzending"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Omleiden naar"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr ""
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Label met opmaak"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr "opslaan"
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr "Opslag"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Opslag"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr "Stel het standaardscheidingsteken in voor CSV-downloads"
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr "Maximale grootte (in bytes) voor bestanden die kunnen worden opgeladen"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr "Onderwerp"
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "'Bedankt' pagina"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Deze velden zijn beschikbaar voor het formulier"
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traverseren naar"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Jouw e-mailadres"
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Verzend"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Bedankt voor je bijdrage"
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Bedankt"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Markeer dit veld als een waarde die in het request formulier geïnjecteerd wordt voor gebruik door acties en die niet te wijzigen is door of zichtbaar is voor de gebruiker."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr ""
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Een TALES-expressie die zal worden aangeroepen nadat de validatie van het formulier is geslaagd, maar voordat de actie (indien ingesteld) wordt aangeroepen of een 'bedankt' pagina wordt getoond. Formulierinvoer zal worden getoond in request.form 'dictionary'. Indien niet nodig, leeglaten. Meestal wordt dit veld gebruikt om een python-script aan te roepen om de formulierinvoer te wissen of een alternatieve actie te scripten. Elke waarde die door de expressie wordt teruggegeven zal worden genegeerd. MERK OP: fouten in de evaluatie van deze expressie resulteren in een fout bij het tonen van het formulier."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Een TALES-expressie die wordt aangeroepen als het formulier wordt getoond. Laat leeg indien dit niet nodig is. Het is gebruikelijk om dit veld een python-script te laten aanroepen dat alvast standaardwaarden instelt voor meerdere velden via request.form. Elke waarde die door deze expressie wordt teruggeven zal worden genegeerd. MERK OP: fouten in de evaluatie van deze expressie resulteren in een fout bij het tonen van het formulier."
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Een TALES expressie die gebruikt wordt om de waarde van de BCC adreslijst (blinde kopie) te overschrijven. We raden sterk af om niet gevalideerde data uit het request hiervoor te gebruiken. Laat leeg indien dit niet nodig is. De expressie moet een 'string' terug geven. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Een TALES expressie die gebruikt wordt om de waarde van de CC adreslijst (blinde kopie) te overschrijven. We raden sterk af om niet gevalideerde data uit het request hiervoor te gebruiken. Laat leeg indien dit niet nodig is. De expressie moet een 'string' terug geven. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Selecteer dit om Cross-Site Request Forgery aan te zetten. Let op dat alleen HTTP POST acties worden toegestaan."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Dit veld maakt het mogelijk om het standaard fieldset-label te wijzigen"
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Deze tekst zal worden getoond onder de velden van het formulier."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Een TALES-expressie die zal worden geëvalueerd om te bepalen of deze actie moet worden uitgevoerd of niet. Laat leeg indien dit niet nodig is en de actie wordt uitgevoerd."
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Vink dit aan om het formulier om te leiden naar een SSL-ingeschakelde versie van zichzelf (https://) als het wordt geopend via een niet-SSL-URL (http://). Om goed te kunnen functioneren, is een webserver nodig die is geconfigureerd om het HTTPS-protocol op poort 443 af te handelen en door te sturen naar Zope."
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Gebruik dit veld om het actie attribuut van het formulier te overschrijven. Geef een URL op waarnaar gepost zal worden. Dit zal buiten de validatie, succesactie-adapter en 'Bedankt' pagina om gebeuren."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Additionele e-mail headers. Gebruik alleen RFC822-compatible headers."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "E-mailadressen die een BCC zullen ontvangen."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Tekst die als voetnoot gebruikt zal worden, gescheiden van de hoofdtekst met een gestreepte lijn."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Tekst die achter de velden in de tekst van de e-mail wordt geplakt."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Tekst die voor de genoemde velden in het E-mailhoofdtekst wordt geplakt."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Dit is een Zope Page Template die gebruikt wordt voor de weergave van de tekst van de e-mail. Het is niet nodig dit aan te passen, maar als u TAL kent (de Template Attribute Language van Zope) heeft u de volledige controle over de lay-out van de uitgaande e-mails."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Stel het MIME-type in van de e-mailtekst. Verander deze instelling alleen als u exact weet wat u aan het doen bent. Leeg laten voor standaard gedrag."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "E-mailadressen van de CC-ontvangers."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Het e-mailadres van de geadresseerde."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "De volledige naam van de ontvanger van het verstuurde formulier."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Kies een formulierveld waarvan u de invoer wilt extraheren voor de 'Reply-To' header. MERK OP: U moet e-mailadresverificatie activeren voor het desbetreffende veld."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Onderwerpregel van het bericht. Dit wordt gebruikt als u niet een onderwerpveld aangeeft of als het veld leeg is."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Kies een formulierveld vanwaar u de invoer wilt extraheren voor de onderwerpregel van de e-mail."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Kies een formulierveld vanwaar u invoer wilt extraheren voor de \"Aan\" header. Als u iets anders kiest dan \"None\" zal deze het \"Ontvanger e-mailadres\" instelling van hierboven overschrijven. Wees erg voorzichtig met het toestaan van niet gecontroleerde input van gebruikers voor dit doel (om spam tegen te gaan)."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Dit overschrijfveld biedt u de mogelijkheid om inhoud in de xhtml-head toe te voegen. Typisch gebruik hiervan is voor maatwerk CSS of JavaScript. Geef een TALES-expressie op die een 'string' terug geeft. Deze 'string' zal zonder interpretatie worden ingevoegd. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Veld is verborgen"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Schakel deze optie in om titels van lege velden te tonen. Indien uitgeschakeld zullen lege velden niet getoond worden."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Schakel deze optie in om titels van lege velden te tonen. Indien uitgeschakeld zullen lege velden niet getoond worden."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Schakel deze optie in om alle velden te tonen (beehalve label en bestand velden). Indien ingeschakeld zullen de keuzes uit onderstaande keuzeveld genegeerd worden."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Kies de velden waarvan u de invoer in de e-mail wilt opnemen."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Deze tekst zal worden getoond boven de velden van het formulier."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Een TALES expressie die gebruikt wordt om de waarde van het e-mailadres van de afzender te overschrijven. We raden sterk af om niet gevalideerde data uit het request hiervoor te gebruiken. Laat leeg indien dit niet nodig is. De expressie moet een 'string' terug geven. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Selecteer welke extra gegevens u wilt opslaan bij het formulier."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Selecteer hier welke velden moeten worden opgeslagen. Indien leeg, worden alle invoer opgeslagen. "
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Schrijf hier uw script."
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Rol waarmee dit script wordt uitgevoerd."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Selecteer dit om een ​​CSV-bestandsbijlage te verzenden met de waarden die in het formulier zijn ingevuld. "
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Selecteer dit om een ​​XML-bestandsbijlage te verzenden met de waarden die in het formulier zijn ingevuld."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden om het \"Van\" veld te overschrijven. Laat leeg indien dit niet nodig is. De expressie moet een 'string' opleveren. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Selecteer dit om de gegevens van alle velden te tonen (behalve de label- en bestandsvelden). Als u dit selecteert worden de keuzes in de selectiebox hieronder genegeerd."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Selecteer de velden waarvan u de gegevens wilt tonen op de succespagina."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden om elke andere waarde van de onderwerp header te overschrijven. Laat leeg indien dit niet nodig is. De expressie moet een 'string' opleveren. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier"
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Dit overschrijfveld biedt u de mogelijkheid om de tekst voor de verzendknop aan te passen. Typisch wordt dit label ingesteld met verzoekparameters. Geef een TALES-expressie op die een 'string' terug geeft. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden als het formulier wordt getoond om de standaardwaarde van het veld te verkrijgen. Laat leeg indien dit niet nodig is. De expressie moet een 'string' opleveren. MERK OP: fouten in de validatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Een TALES-expressie die geëvalueerd zal worden wanneer het formulier getoond wordt, om te bepalen of het veld aan staat. De expressie moet een 'True' waarde opleveren wanneer het veld op het formulier moet staan en 'False' wanneer het kan worden weggelaten. Laat leeg indien dit niet nodig is: het veld zal dan worden opgenomen in het formulier. MERK OP: fouten in de evaluatie van deze expressie zullen leiden tot fouten in het tonen van het formulier."
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Wordt in de 'bedankt'-pagina gebruikt."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Deze tekst zal onder de ingevulde gegevens worden getoond."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Gebruik dit veld in plaats van een 'Bedankt' pagina, om de laatste actie te bepalen na het aanroepen van de formulieractie (indien u deze heeft geselecteerd). Normaal gesproken zou u hiervoor een aangepast 'geslaagd' sjabloon of script gebruiken. Laat leeg als het niet nodig is. Anders invullen alsof u een 'CMFFormController' actie type en argument zou opgeven, compleet met het type actie dat moet worden uitgevoerd (bv. \"redirect_to\" of \"traverse_to\") en een TALES-expressie. Bijvoorbeeld, \"redirect_to:string:thanks-page\" zal u doorsturen naar 'thanks-page'."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Gebruik dit veld in plaats van een 'Bedankt' pagina, om de laatste actie te bepalen na het aanroepen van de formulieractie (indien u deze heeft geselecteerd). Normaal gesproken zou u hiervoor een aangepast 'geslaagd' sjabloon of script gebruiken. Laat leeg als het niet nodig is. Anders invullen alsof u een 'CMFFormController' actie type en argument zou opgeven, compleet met het type actie dat moet worden uitgevoerd (bv. \"redirect_to\" of \"traverse_to\") en een TALES-expressie. Bijvoorbeeld, \"redirect_to:string:thanks-page\" zal u doorsturen naar 'thanks-page'."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Deze tekst zal boven de ingevulde gegevens worden getoond."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Een TALES-expressie die wordt geëvalueerd als het formulier wordt gevalideerd. Validatie is tegen 'value' welke de formulierinvoer zal bevatten. Geeft 'False' terug indien valide; indien niet valide wordt een 'string' met foutmelding teruggegeven. Voorbeeld: \"python: test(value=='eieren', False, 'invoer moet eieren zijn')\" stelt \"eieren\" als verplichte invoer. MERK OP: fouten in deze expressie zullen resulteren in een fout bij het weergeven van het formulier."
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Kolomnamen tonen"
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Selecteer de validators voor dit veld"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Selecteer welke HTTP Headers u als extra headers wilt invoegen in het bericht."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "importeer"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script na validatie"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Formulier opstart script"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "BCC expressie"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "CC Expressie"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "CSRF beveiliging"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "Aangepast script"
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Eigen standaard Fieldset-label"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Download formaat"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Formulier nawoord"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Conditie"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Veldwidget"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "SSL-verbinding forceren"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Zet fieldsets om in tabbladen"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Maatwerkformulieractie"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Additionele Headers"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "BCC-ontvangers"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Hoofdtekst (ondertekening)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Hoofdtekst (achteraan geplakt)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Hoofdtekst (Proloog)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Sjabloon voor hoofdtekst van email"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "E-mail hoofdtekst type"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "CC geadresseerden"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "E-mailadres van geadresseerde"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Naam van geadresseerde"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Gebruik Reply-To van"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Onderwerp"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Gebruik onderwerp van"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Gebruik ontvanger van"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Header Injectie"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Verborgen"
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Velden met lege waarden toevoegen"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr ""
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Velden met lege waarden toevoegen"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Alle velden toevoegen"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Toon ingevulde gegevens"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Formulier methode"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Formulier voorwoord"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr ""
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Geadresseerde expressie"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Label resetknop"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Label met opmaak"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "Opslag"
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr ""
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Opgeslagen velden"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Script inhoud"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy rol"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "CSV-gegevensbijlage verzenden"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "XML-gegevensbijlage verzenden"
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Afzender expressie"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Server-Side Variabele"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Toon alle velden"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Toon knop 'Wissen'"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Toon ingevulde gegevens"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Onderwerp expressie"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Tekst voor knop verzenden"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Tekst voor eigen verzendknop"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Standaard expressie"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Ingeschakelde expressie"
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "'Bedankt' samenvatting"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "'Bedankt' nawoord"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Aangepaste succesactie"
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Type van aangepaste succesactie"
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "'Bedankt' voorwoord"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "'Bedankt' titel"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Aangepaste validatie"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Bescherming lossen"
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Kolomnamen opnemen"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr ""
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr "Het bestandstype ${ftype} is niet toegestaan ​​als upload"
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr "Het geüploade bestand is groter dan ${size} bytes."
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Door komma's gescheiden waarden (CSV)"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Datum en tijd waarop het formulier is verzonden"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Door tabs gescheiden waarden (TSV)"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2019-11-28 17:09+0100\n"
 "Last-Translator: Érico Andrei <ericof@plone.org>\n"
 "Language-Team: \n"
@@ -14,1010 +14,1019 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.easyform\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} resposta(s) salvas"
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Tipo de ação"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modelo de ação"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Adicionar nova ação"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Endereçamento"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Campos permitidos"
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Limpar tudo"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Definir ações do formulário"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Definir campos do formulário"
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "Formulário"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar ação '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Editar o XML do modelo de ação"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Editar o XML do modelo de campos"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Exportar"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modelo de campos"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulário importado"
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Cabeçalhos"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Importar"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Links não são permitidos."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Deve ser uma lista de endereços de email válidos (separados por vírgulas)."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Deve estar selecionado."
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Deve estar não selecionado."
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Substituições"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Data/Hora do envio"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Redirecionar para"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Limpar"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Rótulo rico"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Dados salvos"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Página de agradecimento"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Estes campos estão disponíveis para seus formulários"
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traverse para"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validadores."
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Limpar"
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Enviar"
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Obrigado pelo envio"
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Obrigado"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Marca este campo como um valor a ser enviado na requisição para ser utilizado pelas ações do formulário, mas não ser modificado ou exibido aos usuários."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "Cabeçalho ${name}"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário não é validado, mas antes de chamar um adaptador de ação ou exibir a página de agradecimento. Dados do formulário estarão em no dicionário request.form. Deixe em branco se não for necessário. O caso de uso mais comum para este campo é chamar um script Python para limpar os dados do formulário ou para direcionar para uma ação alternativa. Qualquer valor retornado é ignorado. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário é exibido. Deixe em branco se não for necessário. O caso de uso mais comum é chamar um script Python para popular valores padrão para campos do formulário. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever valores do campo BCC. Recomendamos fortemente utilizar dados não validados do formulário para este propósito. Deixe em branco se não for necessário. Sua expressão deve retornar uma sequência de strings. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever valores do campo CC. Recomendamos fortemente utilizar dados não validados do formulário para este propósito. Deixe em branco se não for necessário. Sua expressão deve retornar uma sequência de strings. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Selecione isto para aplicar proteção contra Cross-Site Request Forgery (CSRF). Apenas ações HTTP Post são suportadas."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Este campo permite a modificação do rótulo do fieldset padrão."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "O texto será exibido após os campos do formulário."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Uma expressão TALES que será avaliada para determinar se esta ação deve ser executada. Deixe em branco se não for necessário e a ação será executada. Sua expressão deve retornar um valor boleano; Retorne True caso queira que a ação seja executada. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Selecione esta opção para fazer o formulário sempre redirecionar para uma versão SSL (https://) quando acessado via uma URL não segura (http://). Para que isto funcione é necessário que o servidor web suporte o protocolo HTTPS na porta 443 e repasse as requisições para o Zope."
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Utilize este campo para sobrescrever o atributo de ação do formulário. Informe a URL para a qual o formulário será enviado. Isto ignorará as validações, ação de sucesso e a página de agradecimento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Cabeçalhos de e-mail adicionais. Apenas use cabeçalhos compatíveis com a RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Endereços de e-mail que receberão uma cópia oculta."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Texto utilizado como rodapé, delimitado do corpo por uma linha tracejada."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Texto que sucede os campos listados no corpo do email."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Texto que precede os campos listados no corpo do email."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Este é um Zope Page Template usado para renderizar o corpo do e-mail. Você não precisa modificá-lo, mas caso conheça a Zope Template Attribute Language, você terá total controle sobre a personalização do envio de e-mails."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Define o mime-type do corpo do e-mail. Altere este valor apenas se souber o que está fazendo. Deixe em branco para o comportamento padrão."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Endereços de e-mail que receberão uma cópia da mensagem."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Endereço de e-mail do destinatário."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Nome do destinatário do formulário."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o cabeçalho Reply-To. AVISO: Você deve ativar a verificação do endereço de e-mail para este campo."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Assunto da mensagem. Isto é usado caso você não tenha um campo para assunto ou se o campo estiver em branco."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o Assunto to e-mail."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o cabeçalho destinatário (To). Se você escolher qualquer opção diferente de \"None\", isto sobreescreverá o email do destinatário informado acima."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Esta sobreescrita de campo permite que você insira conteúdo dentro do cabeçalho XHTML. Os usos mais comuns são adicionar CSS personalizado ou código JavaScript. Informe uma expressão TALES retornando uma string. A string será inserida sem nenhuma intepretação. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Campo oculto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Selectione para exibir os títulos de campo para campos que não receberam nenhum valor. Deixe desselecionado para que os campos sem valores fiquem fora da lista."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Selectione para exibir os títulos de campo para campos que não receberam nenhum valor. Deixe desselecionado para que os campos sem valores fiquem fora do e-mail"
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Selectione para exibir os valores para todos os campos (exceção feita a rótulos e campos arquivo). Caso selecione esta opção, ignoraremos as opções seguintes."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Escolha campos que terão seus valores incluídos no e-mail."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Este texto será exibido acima dos campos do formulário."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valor informado como endereço do destinatário de e-mail. Recomendamos fortemente que seja utilizado qualquer valor não validado para este propósito. Deixe em branco caso não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Selecione quaisquer dados extra que você deseja salvar com os valores do formulário."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Selecione os campos que você deseja ter nos dados salvos. Caso vazio, todos os campos serão salvos."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Escreva seu script aqui."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Papel que executará este script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Selecione esta opção para enviar um arquivo CSV anexado contendo os valores preenchidos no formulário."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Selecione esta opção para enviar um arquivo XML anexado contendo os valores preenchidos no formulário."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever o cabeçalho \"From\". Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Selecione esta opção para exibir os valores de todos os campos (exceção feita a rótulos e campos do tipo arquivo). Caso escolha esta opção, as opções da caixa de seleção serão ignoradas."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Selecione os campos que devem ter seus valores exibidos na página de sucesso."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valor informado para o cabeçalho de assunto do e-mail. Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Esta sobreescrita de campo permite que altere o rótulo do botão de envio. O caso de uso é alterar o rótulo utilizando parâmetros da requisição. Informe uma expressão TALES retornando uma string. A string será inserida sem nenhuma intepretação AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário. "
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Uma expressão TALES que será avaliada para exibir o valor padrão para o campo quando o formulário for exibido. Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Uma expressão TALES que será avaliada para definir se um campo está disponível. Esta expressão deve retornar True caso o campo deva ser exibido ou False caso ele não deva ser exibido. Deixe em branco se não necessário. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Utilizado na página de agradecimento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "O texto será exibido após os valores dos campos."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Use este campo ao invés de uma página de agradecimento para determinar qual a ação final após chamar seu adaptador de ação (Caso você tenha algum). Normalmente este campo é utilizado com um script personalizado. Deixe em branco caso não necessário. Caso contrário, informe uma ação do CMFFormController e seu argumento. Por exemplo, \"Redirect to\" e \"string:thanks-page\" para redirecionar para \"thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Use este campo ao invés de uma página de agradecimento para determinar qual a ação final após chamar seu adaptador de ação (Caso você tenha algum). Normalmente este campo é utilizado com um script personalizado. Deixe em branco caso não necessário. Caso contrário, informe uma ação do CMFFormController e seu argumento. Por exemplo, \"Redirect to\" e \"string:thanks-page\" para redirecionar para \"thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Este texto será exibido acima dos valores de campos escolhidos."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário é validado. Valide contra 'value', que conterá a entrada do campo. Retorna False se válido, caso contrário retorna uma mensagem de erro. Exemplo: \"python: test(value=='ovos', False, 'valor deve ser ovos')\" obrigará o valor de \"ovos\" para a entrada. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Você quer ter os nomes de colunas na primeira linha do arquivo a ser baixado?"
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Selecione os validadores a serem utilizados neste campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Escolha qualquer informação dos cabeçalhos HTTP para ser inserido como cabeçalho X- na mensagem."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "importar"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script pós-validação"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script para configuração do formulário"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Expressão para BCC"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Expressão para CC"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Proteção CSRF"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personalizado"
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Rótulo personalizado para o fieldset padrão"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Formato de download"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epílogo do formulário"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condição de execução"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Widget do campo"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forçar conexão SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Converter fieldsets para abas"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Ação de formulário personalizada"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Cabeçalhos adicionais"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinatários em cópia oculta (BCC)"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Corpo (assinatura)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Corpo (acrescentar)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Corpo (preceder)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Modelo do corpo do email"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Formato do email"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinatários em cópia (CC)"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "E-mail do destinatário"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nome do destinatário"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Extrair 'responder para' de"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Assunto"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Extrair assunto de"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Extrair destinatário de"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Injeção no cabeçalho"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Oculto"
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Incluir campos vazios"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "Rótulo"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Incluir campos vazios"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Incluir todos os campos"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr "Mailer"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Exibir respostas"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Método do formulário"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prólogo do formulário"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Expressão do destinatário"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Rótulo do botão de limpeza"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Rótulo rico"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr "Salvar dados"
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Dados extra"
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Campos salvos"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Corpo do script"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy role"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Enviar anexo de dados CSV"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Enviar anexo de dados XML"
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Expressão de remetente"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variável Server-side"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Exibir todos os campos"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Exibir botão de limpeza"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Exibir respostas"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Expressão da submissão"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Rótulo do botão de submissão"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Rótulo do botão de submissão personalizado"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Expressão padrão"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Expressão de ativação"
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Sumário da página de agradecimento"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epílogo da página de agradecimento"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Ação de sucesso personalizada"
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Tipo de ação de sucesso personalizada"
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prólogo da página de agradecimento"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Título da página de agradecimento"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validador personalizado"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Proteção contra mudança de página"
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Incluir nome de colunas"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "Cabeçalhos HTTP"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Valores separados por vírgula"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Data/Hora do envio"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Valores separados por tabulação"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2019-11-28 17:09+0100\n"
 "Last-Translator: Érico Andrei <ericof@plone.org>\n"
 "Language-Team: \n"
@@ -14,1019 +14,1019 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: collective.easyform\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} resposta(s) salvas"
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Tipo de ação"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Modelo de ação"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Adicionar nova ação"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Endereçamento"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr "Campos permitidos"
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Limpar tudo"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr "Definir ações do formulário"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr "Definir campos do formulário"
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "Formulário"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar ação '${fieldname}'"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Editar o XML do modelo de ação"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Editar o XML do modelo de campos"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Exportar"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Modelo de campos"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Formulário importado"
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Cabeçalhos"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Importar"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Links não são permitidos."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Deve ser uma lista de endereços de email válidos (separados por vírgulas)."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Deve estar selecionado."
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Deve estar não selecionado."
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Substituições"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Data/Hora do envio"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Redirecionar para"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Limpar"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Rótulo rico"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Dados salvos"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Página de agradecimento"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr "Estes campos estão disponíveis para seus formulários"
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Traverse para"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Validadores."
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr "Limpar"
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr "Enviar"
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr "Obrigado pelo envio"
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr "Obrigado"
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Marca este campo como um valor a ser enviado na requisição para ser utilizado pelas ações do formulário, mas não ser modificado ou exibido aos usuários."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "Cabeçalho ${name}"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 msgid "help_AfterValidationOverride_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário não é validado, mas antes de chamar um adaptador de ação ou exibir a página de agradecimento. Dados do formulário estarão em no dicionário request.form. Deixe em branco se não for necessário. O caso de uso mais comum para este campo é chamar um script Python para limpar os dados do formulário ou para direcionar para uma ação alternativa. Qualquer valor retornado é ignorado. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário é exibido. Deixe em branco se não for necessário. O caso de uso mais comum é chamar um script Python para popular valores padrão para campos do formulário. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever valores do campo BCC. Recomendamos fortemente utilizar dados não validados do formulário para este propósito. Deixe em branco se não for necessário. Sua expressão deve retornar uma sequência de strings. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever valores do campo CC. Recomendamos fortemente utilizar dados não validados do formulário para este propósito. Deixe em branco se não for necessário. Sua expressão deve retornar uma sequência de strings. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Selecione isto para aplicar proteção contra Cross-Site Request Forgery (CSRF). Apenas ações HTTP Post são suportadas."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Este campo permite a modificação do rótulo do fieldset padrão."
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "O texto será exibido após os campos do formulário."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 msgid "help_execcondition_text"
 msgstr "Uma expressão TALES que será avaliada para determinar se esta ação deve ser executada. Deixe em branco se não for necessário e a ação será executada. Sua expressão deve retornar um valor boleano; Retorne True caso queira que a ação seja executada. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário"
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Selecione esta opção para fazer o formulário sempre redirecionar para uma versão SSL (https://) quando acessado via uma URL não segura (http://). Para que isto funcione é necessário que o servidor web suporte o protocolo HTTPS na porta 443 e repasse as requisições para o Zope."
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Utilize este campo para sobrescrever o atributo de ação do formulário. Informe a URL para a qual o formulário será enviado. Isto ignorará as validações, ação de sucesso e a página de agradecimento."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Cabeçalhos de e-mail adicionais. Apenas use cabeçalhos compatíveis com a RFC822."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Endereços de e-mail que receberão uma cópia oculta."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Texto utilizado como rodapé, delimitado do corpo por uma linha tracejada."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Texto que sucede os campos listados no corpo do email."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Texto que precede os campos listados no corpo do email."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 msgid "help_formmailer_body_pt"
 msgstr "Este é um Zope Page Template usado para renderizar o corpo do e-mail. Você não precisa modificá-lo, mas caso conheça a Zope Template Attribute Language, você terá total controle sobre a personalização do envio de e-mails."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Define o mime-type do corpo do e-mail. Altere este valor apenas se souber o que está fazendo. Deixe em branco para o comportamento padrão."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Endereços de e-mail que receberão uma cópia da mensagem."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Endereço de e-mail do destinatário."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Nome do destinatário do formulário."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o cabeçalho Reply-To. AVISO: Você deve ativar a verificação do endereço de e-mail para este campo."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Assunto da mensagem. Isto é usado caso você não tenha um campo para assunto ou se o campo estiver em branco."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o Assunto to e-mail."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 msgid "help_formmailer_to_extract"
 msgstr "Escolha um campo do qual será extraído o valor para o cabeçalho destinatário (To). Se você escolher qualquer opção diferente de \"None\", isto sobreescreverá o email do destinatário informado acima."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Esta sobreescrita de campo permite que você insira conteúdo dentro do cabeçalho XHTML. Os usos mais comuns são adicionar CSS personalizado ou código JavaScript. Informe uma expressão TALES retornando uma string. A string será inserida sem nenhuma intepretação. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr "Campo oculto"
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Selectione para exibir os títulos de campo para campos que não receberam nenhum valor. Deixe desselecionado para que os campos sem valores fiquem fora da lista."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Selectione para exibir os títulos de campo para campos que não receberam nenhum valor. Deixe desselecionado para que os campos sem valores fiquem fora do e-mail"
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Selectione para exibir os valores para todos os campos (exceção feita a rótulos e campos arquivo). Caso selecione esta opção, ignoraremos as opções seguintes."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Escolha campos que terão seus valores incluídos no e-mail."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Este texto será exibido acima dos campos do formulário."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valor informado como endereço do destinatário de e-mail. Recomendamos fortemente que seja utilizado qualquer valor não validado para este propósito. Deixe em branco caso não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Selecione quaisquer dados extra que você deseja salvar com os valores do formulário."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Selecione os campos que você deseja ter nos dados salvos. Caso vazio, todos os campos serão salvos."
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Escreva seu script aqui."
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Papel que executará este script."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr "Selecione esta opção para enviar um arquivo CSV anexado contendo os valores preenchidos no formulário."
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr "Selecione esta opção para enviar um arquivo XML anexado contendo os valores preenchidos no formulário."
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever o cabeçalho \"From\". Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Selecione esta opção para exibir os valores de todos os campos (exceção feita a rótulos e campos do tipo arquivo). Caso escolha esta opção, as opções da caixa de seleção serão ignoradas."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Selecione os campos que devem ter seus valores exibidos na página de sucesso."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "Uma expressão TALES que será avaliada para sobreescrever qualquer valor informado para o cabeçalho de assunto do e-mail. Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Esta sobreescrita de campo permite que altere o rótulo do botão de envio. O caso de uso é alterar o rótulo utilizando parâmetros da requisição. Informe uma expressão TALES retornando uma string. A string será inserida sem nenhuma intepretação AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário. "
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 msgid "help_tdefault_text"
 msgstr "Uma expressão TALES que será avaliada para exibir o valor padrão para o campo quando o formulário for exibido. Deixe em branco se não necessário. Esta expressão deve retornar uma string. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "Uma expressão TALES que será avaliada para definir se um campo está disponível. Esta expressão deve retornar True caso o campo deva ser exibido ou False caso ele não deva ser exibido. Deixe em branco se não necessário. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Utilizado na página de agradecimento."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "O texto será exibido após os valores dos campos."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Use este campo ao invés de uma página de agradecimento para determinar qual a ação final após chamar seu adaptador de ação (Caso você tenha algum). Normalmente este campo é utilizado com um script personalizado. Deixe em branco caso não necessário. Caso contrário, informe uma ação do CMFFormController e seu argumento. Por exemplo, \"Redirect to\" e \"string:thanks-page\" para redirecionar para \"thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Use este campo ao invés de uma página de agradecimento para determinar qual a ação final após chamar seu adaptador de ação (Caso você tenha algum). Normalmente este campo é utilizado com um script personalizado. Deixe em branco caso não necessário. Caso contrário, informe uma ação do CMFFormController e seu argumento. Por exemplo, \"Redirect to\" e \"string:thanks-page\" para redirecionar para \"thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Este texto será exibido acima dos valores de campos escolhidos."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "Uma expressão TALES que será avaliada quando o formulário é validado. Valide contra 'value', que conterá a entrada do campo. Retorna False se válido, caso contrário retorna uma mensagem de erro. Exemplo: \"python: test(value=='ovos', False, 'valor deve ser ovos')\" obrigará o valor de \"ovos\" para a entrada. AVISO: Erros na validação desta expressão acarretarão erros na exibição do formulário."
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Você quer ter os nomes de colunas na primeira linha do arquivo a ser baixado?"
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Selecione os validadores a serem utilizados neste campo"
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Escolha qualquer informação dos cabeçalhos HTTP para ser inserido como cabeçalho X- na mensagem."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "importar"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Script pós-validação"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Script para configuração do formulário"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Expressão para BCC"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Expressão para CC"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Proteção CSRF"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr "Script personalizado"
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Rótulo personalizado para o fieldset padrão"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Formato de download"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Epílogo do formulário"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Condição de execução"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Widget do campo"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Forçar conexão SSL"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Converter fieldsets para abas"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Ação de formulário personalizada"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Cabeçalhos adicionais"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Destinatários em cópia oculta (BCC)"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Corpo (assinatura)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Corpo (acrescentar)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Corpo (preceder)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Modelo do corpo do email"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Formato do email"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Destinatários em cópia (CC)"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "E-mail do destinatário"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Nome do destinatário"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Extrair 'responder para' de"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Assunto"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Extrair assunto de"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Extrair destinatário de"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Injeção no cabeçalho"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr "Oculto"
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Incluir campos vazios"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "Rótulo"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Incluir campos vazios"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Incluir todos os campos"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr "Mailer"
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Exibir respostas"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Método do formulário"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Prólogo do formulário"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Expressão do destinatário"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Rótulo do botão de limpeza"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Rótulo rico"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr "Salvar dados"
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Dados extra"
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Campos salvos"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Corpo do script"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Proxy role"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr "Enviar anexo de dados CSV"
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr "Enviar anexo de dados XML"
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Expressão de remetente"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Variável Server-side"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Exibir todos os campos"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Exibir botão de limpeza"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Exibir respostas"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Expressão da submissão"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Rótulo do botão de submissão"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Rótulo do botão de submissão personalizado"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Expressão padrão"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr "Expressão de ativação"
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Sumário da página de agradecimento"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Epílogo da página de agradecimento"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr "Ação de sucesso personalizada"
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr "Tipo de ação de sucesso personalizada"
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Prólogo da página de agradecimento"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Título da página de agradecimento"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Validador personalizado"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr "Proteção contra mudança de página"
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Incluir nome de colunas"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "Cabeçalhos HTTP"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Valores separados por vírgula"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Data/Hora do envio"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Valores separados por tabulação"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2023-08-09 07:42+0000\n"
+"POT-Creation-Date: 2024-12-09 11:59+0000\n"
 "PO-Revision-Date: 2015-10-13 11:16+0200\n"
 "Last-Translator: Zoriana Zaiats <sorenabell@quintagroup.com>\n"
 "Language-Team: Ukrainian <support@quintagroup.com>\n"
@@ -17,1015 +17,1024 @@ msgstr ""
 "Language: uk\n"
 "X-Generator: Poedit 1.7.6\n"
 
-#: collective/easyform/browser/actions.py:137
+#: ./browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} елементів збережено."
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:51
+#: ./interfaces/actions.py:51
 msgid "Action type"
 msgstr "Тип дії"
 
-#: collective/easyform/interfaces/easyform.py:93
+#: ./interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Модель дій"
 
-#: collective/easyform/browser/actions.py:292
+#: ./browser/actions.py:292
 msgid "Add new action"
 msgstr "Додати нову дію"
 
-#: collective/easyform/interfaces/mailer.py:85
+#: ./interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Адреси"
 
-#: collective/easyform/interfaces/easyform.py:197
-#: collective/easyform/interfaces/fields.py:64
+#: ./interfaces/easyform.py:197
+#: ./interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:20
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:20
+#: ./profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:105
+#: ./interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:30
-#: collective/easyform/browser/saveddata_form.pt:39
+#: ./browser/controlpanel.py:30
+#: ./browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:42
+#: ./browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: collective/easyform/browser/saveddata.pt:7
+#: ./browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: collective/easyform/browser/actions.py:175
+#: ./browser/actions.py:175
 msgid "Clear all"
 msgstr "Очистити все"
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:108
+#: ./interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form actions"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Define form fields"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: collective/easyform/profiles/default/types/EasyForm.xml
+#: ./profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: collective/easyform/browser/actions.py:355
+#: ./browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Редагувати дію '${fieldname}'"
 
-#: collective/easyform/browser/actions.py:360
+#: ./browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Редагувати XML модель дій"
 
-#: collective/easyform/browser/fields.py:106
+#: ./browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Редагувати XML модель полів"
 
-#: collective/easyform/interfaces/fields.py:232
+#: ./interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: collective/easyform/browser/fields.py:195
+#: ./browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: collective/easyform/browser/fields.py:187
+#: ./browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Export"
 msgstr "Експортувати"
 
-#: collective/easyform/interfaces/fields.py:94
+#: ./interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:90
+#: ./interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Модель полів"
 
-#: collective/easyform/browser/controlpanel.py:38
+#: ./browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: collective/easyform/interfaces/mailer.py:32
+#: ./interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: collective/easyform/browser/exportimport.py:56
+#: ./browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Форму імпортовано."
 
-#: collective/easyform/interfaces/mailer.py:366
+#: ./interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Заголовки"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Import"
 msgstr "Імпорт"
 
-#: collective/easyform/validators.py:62
+#: ./validators.py:63
 msgid "Links are not allowed."
 msgstr "Лінки заборонені."
 
-#: collective/easyform/browser/saveddata.pt:6
+#: ./browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: collective/easyform/default_schemata/actions_default.xml
+#: ./default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: collective/easyform/validators.py:37
+#: ./validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Повинен бути список дійсних електронних адрес (розділений комами)."
 
-#: collective/easyform/validators.py:47
+#: ./validators.py:48
 msgid "Must be checked."
 msgstr "Має бути вибрано."
 
-#: collective/easyform/validators.py:52
+#: ./validators.py:53
 msgid "Must be unchecked."
 msgstr "Не має бути вибрано."
 
-#: collective/easyform/browser/saveddata.pt:25
+#: ./browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: collective/easyform/interfaces/actions.py:77
-#: collective/easyform/interfaces/easyform.py:304
-#: collective/easyform/interfaces/fields.py:117
+#: ./interfaces/actions.py:77
+#: ./interfaces/easyform.py:312
+#: ./interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Перевизначення"
 
-#: collective/easyform/interfaces/fields.py:239
+#: ./interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:231
+#: ./interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: collective/easyform/interfaces/savedata.py:19
+#: ./interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Дата/час заповнення"
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Redirect to"
 msgstr "Перенаправити до"
 
-#: collective/easyform/browser/view.py:220
+#: ./browser/view.py:224
 msgid "Reset"
 msgstr "Відновити"
 
-#: collective/easyform/interfaces/fields.py:201
+#: ./interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Розширений напис"
 
-#: collective/easyform/browser/fields.py:98
+#: ./browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: collective/easyform/browser/saveddata_form.pt:9
+#: ./browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Збережені дані"
 
-#: collective/easyform/browser/controlpanel.py:32
+#: ./browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: collective/easyform/browser/controlpanel.py:39
+#: ./browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: collective/easyform/interfaces/easyform.py:117
+#: ./interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Сторінка подяки"
 
-#: collective/easyform/browser/controlpanel.py:21
-#: collective/easyform/profiles/default/registry.xml
+#: ./browser/controlpanel.py:21
+#: ./profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr ""
 
-#: collective/easyform/interfaces/fields.py:97
+#: ./interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: collective/easyform/vocabularies.py:30
+#: ./vocabularies.py:30
 msgid "Traverse to"
 msgstr "Траверсити до"
 
-#: collective/easyform/interfaces/fields.py:76
+#: ./interfaces/fields.py:76
 msgid "Validators"
 msgstr "Валідатори"
 
-#: collective/easyform/profiles/default/actions.xml
+#: ./profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: collective/easyform/default_schemata/fields_default.xml
+#: ./default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: collective/easyform/interfaces/easyform.py:34
+#: ./interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: collective/easyform/interfaces/easyform.py:26
+#: ./interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: collective/easyform/interfaces/easyform.py:50
+#: ./interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: collective/easyform/interfaces/easyform.py:42
+#: ./interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr ""
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: collective/easyform/interfaces/fields.py:174
+#: ./interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Позначити це поле як значення, що буде вставлене у форму запиту, що використовуватиметься адаптерами дії, і не буде модифікуватись чи надаватись клієнту."
 
-#: collective/easyform/browser/controlpanel.py:47
+#: ./browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: collective/easyform/interfaces/mailer.py:397
-#: collective/easyform/interfaces/savedata.py:22
+#: ./interfaces/mailer.py:397
+#: ./interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} Заголовок"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: collective/easyform/interfaces/easyform.py:398
+#: ./interfaces/easyform.py:406
 #, fuzzy
 msgid "help_AfterValidationOverride_text"
 msgstr "TALES вираз, який буде викликано після успішної перевірки форми, але до виклику адаптера дії (якщо такий є), чи відображення сторінки подяки. Вміст форми буде у словнику request.form. Заповнювати поле не обов'язково. Найпоширеніше використання цього поля - для виклику python скрипта, що видаляє дані, введені в форму, або для додання альтернативної дії. Будь-яке значення, що поверне цей вираз, буде проігнороване. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:378
+#: ./interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "TALES вираз, який буде викликано при відображенні форми. Заповнювати поле не обов'язково. Найпоширеніше використання цього поля - це виклик python скрипта, що встановлює значення за замовчуванням для багатьох полів у request.form. Будь-яке значення, що поверне цей вираз, буде проігнороване. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
+#: ./interfaces/easyform.py:249
+msgid "help_autofocus"
+msgstr ""
+
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:498
+#: ./interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в список прихованих копій (BСС). Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як послідовність рядків. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:478
+#: ./interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в список копій (СС). Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як послідовність рядків. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: collective/easyform/interfaces/easyform.py:276
+#: ./interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Позначте, щоб застосувати захист від підробки міжсайтових запитів (Cross-Site Request Forgery protection). Пам'ятайте, що лише дії HTTP Post будуть дозволені."
 
 #. Default: "This field allows you to change default fieldset label."
-#: collective/easyform/interfaces/easyform.py:251
+#: ./interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Це поле дозволяє змінити заголовок набору полів за замовчуванням."
 
 #. Default: "The text will be displayed after the form fields."
-#: collective/easyform/interfaces/easyform.py:107
+#: ./interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Текст буде розміщено після полів форми."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: collective/easyform/interfaces/actions.py:82
+#: ./interfaces/actions.py:82
 #, fuzzy
 msgid "help_execcondition_text"
 msgstr "TALES вираз, що буде обчислюватися, щоб визначити - виконувати, чи не виконувати цю дію. Заповнювати поле не обов'язково. Якщо ви залишите поле пустим, дія буде виконуватись. Ваш вираз повинен обчислюватись як логічна змінна: повертає True, якщо ви хочете, щоб дія виконувалась. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: collective/easyform/interfaces/fields.py:70
+#: ./interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: collective/easyform/interfaces/easyform.py:288
+#: ./interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Позначте, щоб форма переходила на свою безпечну версію з SSL протоколом (https://), якщо використовується звичайний URL (http://) без SSL протоколу. Для правильного функціонування, потрібен веб сервер, налаштований для обробки протоколу HTTPS на порті 443 і його перенаправлення на Zope."
 
-#: collective/easyform/interfaces/easyform.py:241
+#: ./interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: collective/easyform/interfaces/easyform.py:364
+#: ./interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Використовуйте це поле, щоб перевизначити властивість дії форми. Вкажіть URL-адресу, куди буде розміщена форма. Це обійде перевірку форми, адаптер успішної дії та сторінку подяки."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: collective/easyform/interfaces/mailer.py:389
+#: ./interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Додаткові рядки заголовка електронного листа. Використовуйте лише RFC822-сумісні заголовки."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: collective/easyform/interfaces/mailer.py:121
+#: ./interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Адреси електронних пошт, які отримають приховані копії."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: collective/easyform/interfaces/mailer.py:225
+#: ./interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Текст, що буде відображатись у нижньому колонтитулі, відділений від основного тексту пунктирною лінією."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:210
+#: ./interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Текст, що буде доданий до полів, перерахованих в основній частині електронного листа."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: collective/easyform/interfaces/mailer.py:195
+#: ./interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Текст, що буде доданий перед полями, перерахованими в основній частині електронного листа."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: collective/easyform/interfaces/mailer.py:341
+#: ./interfaces/mailer.py:341
 #, fuzzy
 msgid "help_formmailer_body_pt"
 msgstr "Це шаблон сторінки у Zope, що використовується для обробки електронного листа. Немає потреби його змінювати, хоча, якщо ви знайомі з  TAL (Template Attribute Language для Zope), то у вас є всі можливості для налаштування вихідних електронних повідомлень."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: collective/easyform/interfaces/mailer.py:356
+#: ./interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Задайте mime тип основної частини електронного листа. Змінюйте налаштування лише тоді, коли ви дійсно впевнені в правильності своїх дій. Залишіть поле пустим для налаштувань за замовчуванням."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: collective/easyform/interfaces/mailer.py:108
+#: ./interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Адреси електронної пошти, які отримають копію листа."
 
 #. Default: "The recipients e-mail address."
-#: collective/easyform/interfaces/mailer.py:77
+#: ./interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Адреса електронної пошти отримувача."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: collective/easyform/interfaces/mailer.py:62
+#: ./interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Повне ім'я отримувача електронного листа з формою."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: collective/easyform/interfaces/mailer.py:134
+#: ./interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Виберіть поле форми, з якого будуть братися дані для заголовка листа-відповіді. ПРИМІТКА: Увімкніть перевірку адрес електронних пошт для цього поля."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: collective/easyform/interfaces/mailer.py:165
+#: ./interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Тема повідомлення. Вона буде використана, якщо поле теми не вказане, або це поле пусте."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: collective/easyform/interfaces/mailer.py:181
+#: ./interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Виберіть поле форми, з якого будуть братися дані для теми листа."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: collective/easyform/interfaces/mailer.py:92
+#: ./interfaces/mailer.py:92
 #, fuzzy
 msgid "help_formmailer_to_extract"
 msgstr "Виберіть поле форми, з якого буде взята інформація для заголовка \"Кому\". Якщо ви виберете будь-що інше крім \"Жоден\", це перекриє налаштування \"Адреса електронної пошти отримувача\" вище. Будьте обережними з введенням цієї інформації."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:418
+#: ./interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Це поле перевизначення дозволяє вставити вміст в xhtml-заголовок. Переважно поле використовується для додавання користувацького CSS або JavaScript коду. Вкажіть TALES вираз, що повертає рядок. Рядок буде вставлено ​​без перетворень. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Field is hidden"
-#: collective/easyform/interfaces/fields.py:88
+#: ./interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: collective/easyform/interfaces/easyform.py:167
+#: ./interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Позначте для відображення назв незаповнених полів. Не позначайте і порожні поля не відображатимуться у списку."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: collective/easyform/interfaces/mailer.py:269
+#: ./interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Позначте для включення назв незаповнених полів. Не позначайте і порожні поля не відображатимуться в електронному листі."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/mailer.py:241
+#: ./interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Позначте, щоб вибрати вхідні дані для всіх полів (крім написів і файлових типів вмісту). При виборі цього пункту, всі нижче перечислені пункти будуть проігноровані."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: collective/easyform/interfaces/mailer.py:256
+#: ./interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Виберіть поля, дані з яких будуть включені в електронний лист."
 
-#: collective/easyform/interfaces/easyform.py:261
+#: ./interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: collective/easyform/interfaces/easyform.py:232
+#: ./interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: collective/easyform/interfaces/easyform.py:99
+#: ./interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Цей текст буде відображатись над полями форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:457
+#: ./interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в поле адреси електронної пошти отримувача. Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: collective/easyform/interfaces/easyform.py:226
+#: ./interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: collective/easyform/interfaces/savedata.py:72
+#: ./interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Виберіть додаткові дані, які будуть збережені разом із введеною в форму інформацією. "
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: collective/easyform/interfaces/savedata.py:60
+#: ./interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Виберіть поля, дані з яких будуть збережені. Якщо жодне поле не вибране, то зберігатимуться всі вхідні дані."
 
 #. Default: "Write your script here."
-#: collective/easyform/interfaces/customscript.py:32
+#: ./interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Додайте ваш скрипт сюди."
 
 #. Default: "Role under which to run the script."
-#: collective/easyform/interfaces/customscript.py:21
+#: ./interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Роль від якої запускатиметься скрипт."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:283
+#: ./interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: collective/easyform/interfaces/mailer.py:297
+#: ./interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:310
+#: ./interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: collective/easyform/interfaces/mailer.py:325
+#: ./interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:438
+#: ./interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення заголовка \"Від кого\". Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: collective/easyform/interfaces/easyform.py:143
+#: ./interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Позначте, щоб відображати вхідні дані для всіх полів (крім заголовків/написів і файлових типів вмісту). При виборі цього пункту, всі нижче перечислені пункти будуть проігноровані."
 
-#: collective/easyform/interfaces/easyform.py:220
+#: ./interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: collective/easyform/interfaces/easyform.py:156
+#: ./interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Виберіть поля, дані з яких будуть відображатись на сторінці, що повідомлятиме про успішне заповнення форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/mailer.py:419
+#: ./interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в поле заголовка електронного листа. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: collective/easyform/interfaces/easyform.py:214
+#: ./interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/easyform.py:436
+#: ./interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Це поле перевизначення дозволяє змінити напис кнопки Надіслати. Переважно поле використовується для встановлення напису з параметрами запиту. Вкажіть TALES вираз, що повертає рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:123
+#: ./interfaces/fields.py:123
 #, fuzzy
 msgid "help_tdefault_text"
 msgstr "TALES вираз, що буде обчислюватися, коли відображатиметься форма, щоб отримати значення поля за замовчуванням. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:138
+#: ./interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "TALES вираз, що буде обчислюватися коли відображатиметься форма, щоб визначити, чи включене поле. Ваш вираз повинен обчислюватись як True, якщо поле повинне бути включене в форму, False - якщо його треба пропустити. Заповнювати поле не обов'язково. Якщо залишити поле для виразу пустим, поле буде включене. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Used in thanks page."
-#: collective/easyform/interfaces/easyform.py:136
+#: ./interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Використовується на сторінці подяки."
 
 #. Default: "The text will be displayed after the field inputs."
-#: collective/easyform/interfaces/easyform.py:187
+#: ./interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Текст буде відображатись після інформації, вказаної в полі."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:343
+#: ./interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Використовуйте це поле замість призначення сторінки подяки, щоб визначити фінальну дію після виклику адаптера дії (якщо такий є). Переважно використовується для користувацького шаблону чи скрипту. Заповнювати поле не обов'язково. Вкажіть тип дії CMFFormController та аргумент, і доповніть типом дії для виконання (наприклад, \"redirect_to\" або \"traverse_to\") та TALES виразом. Наприклад, \"Redirect to\" і \"string:thanks-page\" переадресує на \"thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: collective/easyform/interfaces/easyform.py:322
+#: ./interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Використовуйте це поле замість призначення сторінки подяки, щоб визначити фінальну дію після виклику адаптера дії (якщо такий є). Переважно використовується для користувацького шаблону чи скрипту. Заповнювати поле не обов'язково. Вкажіть тип дії CMFFormController та аргумент, і доповніть типом дії для виконання (наприклад, \"redirect_to\" або \"traverse_to\") та TALES виразом. Наприклад, \"Redirect to\" і \"string:thanks-page\" переадресує на \"thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: collective/easyform/interfaces/easyform.py:179
+#: ./interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Текст буде відображатись над вибраними полями."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: collective/easyform/interfaces/fields.py:156
+#: ./interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "TALES вираз, що буде обчислюватися після перевірки форми. Перевіряється ’значення’, яке буде містити дані введені в поле. Вернути False, якщо дані вірні, якщо не вірні, то вернути повідомлення про помилку. Наприклад, \"python: test(value=='eggs', False, 'input must be eggs')\" вимагатиме вводити \"eggs\". ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: collective/easyform/interfaces/easyform.py:269
+#: ./interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: collective/easyform/interfaces/savedata.py:86
+#: ./interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Чи відображати назви колонок в першому рядку завантажених даних?"
 
 #. Default: "Select the validators to use on this field"
-#: collective/easyform/interfaces/fields.py:77
+#: ./interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Виберіть валідатори для цього поля."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: collective/easyform/interfaces/mailer.py:373
+#: ./interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Виберіть будь-яку частину HTTP-заголовків, які будуть вставлені як Х-заголовки в повідомлення."
 
-#: collective/easyform/browser/exportimport.py:46
+#: ./browser/exportimport.py:46
 msgid "import"
 msgstr "Імпорт"
 
 #. Default: "After Validation Script"
-#: collective/easyform/interfaces/easyform.py:395
+#: ./interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Скрипт після перевірки"
 
 #. Default: "Form Setup Script"
-#: collective/easyform/interfaces/easyform.py:377
+#: ./interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Скрипт для налаштування форми"
 
+#. Default: "Enable focus on the first input"
+#: ./interfaces/easyform.py:248
+msgid "label_autofocus"
+msgstr ""
+
 #. Default: "BCC Expression"
-#: collective/easyform/interfaces/mailer.py:497
+#: ./interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Вираз для прихованої копії"
 
 #. Default: "CC Expression"
-#: collective/easyform/interfaces/mailer.py:477
+#: ./interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Вираз для копії"
 
 #. Default: "CSRF Protection"
-#: collective/easyform/interfaces/easyform.py:275
+#: ./interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Захист від CSRF атак"
 
 #. Default: "Custom Script"
-#: collective/easyform/actions.py:909
+#: ./actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: collective/easyform/interfaces/easyform.py:247
+#: ./interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Користувацький заголовок стандартного набору полів"
 
 #. Default: "Download Format"
-#: collective/easyform/interfaces/savedata.py:80
+#: ./interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Формат завантаження"
 
 #. Default: "Form Epilogue"
-#: collective/easyform/interfaces/easyform.py:106
+#: ./interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Епілог форми"
 
 #. Default: "Execution Condition"
-#: collective/easyform/interfaces/actions.py:81
+#: ./interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Умова для виконання"
 
 #. Default: "Field Widget"
-#: collective/easyform/interfaces/fields.py:69
+#: ./interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Віджет поля"
 
 #. Default: "Force SSL connection"
-#: collective/easyform/interfaces/easyform.py:287
+#: ./interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Форсувати SSL з’єднання"
 
 #. Default: "Turn fieldsets to tabs"
-#: collective/easyform/interfaces/easyform.py:240
+#: ./interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Перетворити набори полів на таби"
 
 #. Default: "Custom Form Action"
-#: collective/easyform/interfaces/easyform.py:363
+#: ./interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Користувацька дія для форми"
 
 #. Default: "Additional Headers"
-#: collective/easyform/interfaces/mailer.py:388
+#: ./interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Додаткові заголовки"
 
 #. Default: "BCC Recipients"
-#: collective/easyform/interfaces/mailer.py:120
+#: ./interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Отримувачі прихованої копії"
 
 #. Default: "Body (signature)"
-#: collective/easyform/interfaces/mailer.py:224
+#: ./interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Основна частина (підпис)"
 
 #. Default: "Body (appended)"
-#: collective/easyform/interfaces/mailer.py:209
+#: ./interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Основна частина (прикріплено після)"
 
 #. Default: "Body (prepended)"
-#: collective/easyform/interfaces/mailer.py:194
+#: ./interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Основна частина (прикріплено до)"
 
 #. Default: "Mail-Body Template"
-#: collective/easyform/interfaces/mailer.py:340
+#: ./interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Шаблон основної частини листа"
 
 #. Default: "Mail Format"
-#: collective/easyform/interfaces/mailer.py:355
+#: ./interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Формат електронного листа"
 
 #. Default: "CC Recipients"
-#: collective/easyform/interfaces/mailer.py:107
+#: ./interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Отримувачі копії"
 
 #. Default: "Recipient's e-mail address"
-#: collective/easyform/interfaces/mailer.py:74
+#: ./interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Адреса електронної пошти отримувача"
 
 #. Default: "Recipient's full name"
-#: collective/easyform/interfaces/mailer.py:59
+#: ./interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Повне ім'я отримувача"
 
 #. Default: "Extract Reply-To From"
-#: collective/easyform/interfaces/mailer.py:133
+#: ./interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Взяти Відповісти-Кому з"
 
 #. Default: "Subject"
-#: collective/easyform/interfaces/mailer.py:164
+#: ./interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Тема"
 
 #. Default: "Extract Subject From"
-#: collective/easyform/interfaces/mailer.py:180
+#: ./interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Взяти Тему з"
 
 #. Default: "Extract Recipient From"
-#: collective/easyform/interfaces/mailer.py:91
+#: ./interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Взяти Отримувача з"
 
 #. Default: "HCaptcha"
-#: collective/easyform/fields.py:234
+#: ./fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: collective/easyform/interfaces/easyform.py:417
+#: ./interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Вставка заголовку"
 
 #. Default: "Hidden"
-#: collective/easyform/interfaces/fields.py:87
+#: ./interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/easyform.py:166
+#: ./interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Включати пусті поля"
 
 #. Default: "Label"
-#: collective/easyform/fields.py:209
+#: ./fields.py:209
 msgid "label_label_field"
 msgstr "Напис"
 
 #. Default: "Likert"
-#: collective/easyform/fields.py:285
+#: ./fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: collective/easyform/interfaces/mailer.py:268
+#: ./interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Включати пусті поля"
 
 #. Default: "Include All Fields"
-#: collective/easyform/interfaces/mailer.py:240
+#: ./interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Включати всі поля"
 
 #. Default: "Mailer"
-#: collective/easyform/actions.py:904
+#: ./actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/mailer.py:255
+#: ./interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Показати відповіді"
 
 #. Default: "Form method"
-#: collective/easyform/interfaces/easyform.py:260
+#: ./interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Метод форми"
 
 #. Default: "Name attribute"
-#: collective/easyform/interfaces/easyform.py:231
+#: ./interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: collective/easyform/fields.py:245
+#: ./fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: collective/easyform/interfaces/easyform.py:98
+#: ./interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Пролог форми"
 
 #. Default: "ReCaptcha"
-#: collective/easyform/fields.py:224
+#: ./fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: collective/easyform/interfaces/mailer.py:456
+#: ./interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Вираз для Отримувача"
 
 #. Default: "Reset Button Label"
-#: collective/easyform/interfaces/easyform.py:225
+#: ./interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Напис кнопки скидання"
 
 #. Default: "Rich Label"
-#: collective/easyform/fields.py:211
+#: ./fields.py:211
 msgid "label_richlabel_field"
 msgstr "Розширений напис"
 
 #. Default: "Save Data"
-#: collective/easyform/actions.py:914
+#: ./actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: collective/easyform/interfaces/savedata.py:71
+#: ./interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Додаткові дані"
 
 #. Default: "Saved Fields"
-#: collective/easyform/interfaces/savedata.py:59
+#: ./interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Збережені поля"
 
 #. Default: "Script body"
-#: collective/easyform/interfaces/customscript.py:31
+#: ./interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Текст скрипта"
 
 #. Default: "Proxy role"
-#: collective/easyform/interfaces/customscript.py:20
+#: ./interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Проксі роль"
 
 #. Default: "Send CSV data attachment"
-#: collective/easyform/interfaces/mailer.py:282
+#: ./interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: collective/easyform/interfaces/mailer.py:296
+#: ./interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: collective/easyform/interfaces/mailer.py:309
+#: ./interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: collective/easyform/interfaces/mailer.py:324
+#: ./interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: collective/easyform/interfaces/mailer.py:437
+#: ./interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Вираз для Відправника"
 
 #. Default: "Server-Side Variable"
-#: collective/easyform/interfaces/fields.py:173
+#: ./interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Змінна для серверної сторони"
 
 #. Default: "Show All Fields"
-#: collective/easyform/interfaces/easyform.py:142
+#: ./interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Показувати всі поля"
 
 #. Default: "Show Reset Button"
-#: collective/easyform/interfaces/easyform.py:219
+#: ./interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Показувати кнопку скидання"
 
 #. Default: "Show Responses"
-#: collective/easyform/interfaces/easyform.py:155
+#: ./interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Показувати відповіді"
 
 #. Default: "Subject Expression"
-#: collective/easyform/interfaces/mailer.py:418
+#: ./interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Вираз для Теми"
 
 #. Default: "Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:213
+#: ./interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Напис кнопки Надіслати"
 
 #. Default: "Custom Submit Button Label"
-#: collective/easyform/interfaces/easyform.py:433
+#: ./interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Користувацький напис кнопки Надіслати"
 
 #. Default: "Default Expression"
-#: collective/easyform/interfaces/fields.py:122
+#: ./interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Вираз за замовчуванням"
 
 #. Default: "Enabling Expression"
-#: collective/easyform/interfaces/fields.py:137
+#: ./interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: collective/easyform/interfaces/easyform.py:135
+#: ./interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Короткий опис сторінки подяки"
 
 #. Default: "Thanks Epilogue"
-#: collective/easyform/interfaces/easyform.py:186
+#: ./interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Епілог сторінки подяки"
 
 #. Default: "Custom Success Action"
-#: collective/easyform/interfaces/easyform.py:342
+#: ./interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: collective/easyform/interfaces/easyform.py:318
+#: ./interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: collective/easyform/interfaces/easyform.py:178
+#: ./interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Пролог сторінки подяки"
 
 #. Default: "Thanks title"
-#: collective/easyform/interfaces/easyform.py:130
+#: ./interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Назва сторінки подяки"
 
 #. Default: "Custom Validator"
-#: collective/easyform/interfaces/fields.py:155
+#: ./interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Додатковий валідатор"
 
 #. Default: "Unload protection"
-#: collective/easyform/interfaces/easyform.py:268
+#: ./interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: collective/easyform/interfaces/savedata.py:85
+#: ./interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Включати назви колонок"
 
 #. Default: "HTTP Headers"
-#: collective/easyform/interfaces/mailer.py:372
+#: ./interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Заголовки"
 
-#: collective/easyform/browser/view.py:448
+#: ./browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: collective/easyform/browser/view.py:439
+#: ./browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: collective/easyform/browser/saveddata_form.pt:14
+#: ./browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: collective/easyform/vocabularies.py:79
+#: ./vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Значення, розділені комою"
 
 #. Default: "Posting Date/Time"
-#: collective/easyform/vocabularies.py:67
+#: ./vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Дата і час відправлення"
 
 #. Default: "Tab-Separated Values"
-#: collective/easyform/vocabularies.py:78
+#: ./vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Значення, розділені табуляцією"
 
 #. Default: "XLSX"
-#: collective/easyform/vocabularies.py:84
+#: ./vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""

--- a/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2024-12-09 11:59+0000\n"
+"POT-Creation-Date: 2024-12-09 14:39+0000\n"
 "PO-Revision-Date: 2015-10-13 11:16+0200\n"
 "Last-Translator: Zoriana Zaiats <sorenabell@quintagroup.com>\n"
 "Language-Team: Ukrainian <support@quintagroup.com>\n"
@@ -17,1024 +17,1024 @@ msgstr ""
 "Language: uk\n"
 "X-Generator: Poedit 1.7.6\n"
 
-#: ./browser/actions.py:137
+#: ./collective/easyform/browser/actions.py:137
 msgid "${items} input(s) saved"
 msgstr "${items} елементів збережено."
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "A web-form builder"
 msgstr ""
 
-#: ./interfaces/actions.py:51
+#: ./collective/easyform/interfaces/actions.py:51
 msgid "Action type"
 msgstr "Тип дії"
 
-#: ./interfaces/easyform.py:93
+#: ./collective/easyform/interfaces/easyform.py:93
 msgid "Actions Model"
 msgstr "Модель дій"
 
-#: ./browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:292
 msgid "Add new action"
 msgstr "Додати нову дію"
 
-#: ./interfaces/mailer.py:85
+#: ./collective/easyform/interfaces/mailer.py:85
 msgid "Addressing"
 msgstr "Адреси"
 
-#: ./interfaces/easyform.py:197
-#: ./interfaces/fields.py:64
+#: ./collective/easyform/interfaces/easyform.py:197
+#: ./collective/easyform/interfaces/fields.py:64
 msgid "Advanced"
 msgstr ""
 
-#: ./browser/controlpanel.py:20
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:20
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "Allowed Fields"
 msgstr ""
 
-#: ./interfaces/fields.py:105
+#: ./collective/easyform/interfaces/fields.py:105
 msgid "CSS Class"
 msgstr ""
 
-#: ./browser/controlpanel.py:30
-#: ./browser/saveddata_form.pt:39
+#: ./collective/easyform/browser/controlpanel.py:30
+#: ./collective/easyform/browser/saveddata_form.pt:39
 msgid "CSV delimiter"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:42
+#: ./collective/easyform/browser/saveddata_form.pt:42
 msgid "CSV delimiter is required."
 msgstr ""
 
-#: ./browser/saveddata.pt:7
+#: ./collective/easyform/browser/saveddata.pt:7
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:175
 msgid "Clear all"
 msgstr "Очистити все"
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Comments"
 msgstr ""
 
-#: ./interfaces/fields.py:108
+#: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form fields"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "E-Mails Form Input"
 msgstr ""
 
-#: ./profiles/default/types/EasyForm.xml
+#: ./collective/easyform/profiles/default/types/EasyForm.xml
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:355
 msgid "Edit Action '${fieldname}'"
 msgstr "Редагувати дію '${fieldname}'"
 
-#: ./browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:360
 msgid "Edit XML Actions Model"
 msgstr "Редагувати XML модель дій"
 
-#: ./browser/fields.py:106
+#: ./collective/easyform/browser/fields.py:106
 msgid "Edit XML Fields Model"
 msgstr "Редагувати XML модель полів"
 
-#: ./interfaces/fields.py:232
+#: ./collective/easyform/interfaces/fields.py:232
 msgid "Enter allowed choices one per line."
 msgstr ""
 
-#: ./browser/fields.py:195
+#: ./collective/easyform/browser/fields.py:195
 msgid "Error: all model elements must be 'schema'"
 msgstr ""
 
-#: ./browser/fields.py:187
+#: ./collective/easyform/browser/fields.py:187
 msgid "Error: root tag must be 'model'"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Export"
 msgstr "Експортувати"
 
-#: ./interfaces/fields.py:94
+#: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
 msgstr ""
 
-#: ./interfaces/easyform.py:90
+#: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
 msgstr "Модель полів"
 
-#: ./browser/controlpanel.py:38
+#: ./collective/easyform/browser/controlpanel.py:38
 msgid "Filesize limit"
 msgstr ""
 
-#: ./interfaces/mailer.py:32
+#: ./collective/easyform/interfaces/mailer.py:32
 msgid "Form Submission"
 msgstr ""
 
-#: ./browser/exportimport.py:56
+#: ./collective/easyform/browser/exportimport.py:56
 msgid "Form imported."
 msgstr "Форму імпортовано."
 
-#: ./interfaces/mailer.py:366
+#: ./collective/easyform/interfaces/mailer.py:366
 msgid "Headers"
 msgstr "Заголовки"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Import"
 msgstr "Імпорт"
 
-#: ./validators.py:63
+#: ./collective/easyform/validators.py:63
 msgid "Links are not allowed."
 msgstr "Лінки заборонені."
 
-#: ./browser/saveddata.pt:6
+#: ./collective/easyform/browser/saveddata.pt:6
 msgid "List of Save Data Adapters"
 msgstr ""
 
-#: ./default_schemata/actions_default.xml
+#: ./collective/easyform/default_schemata/actions_default.xml
 msgid "Mailer"
 msgstr ""
 
-#: ./validators.py:38
+#: ./collective/easyform/validators.py:38
 msgid "Must be a valid list of email addresses (separated by commas)."
 msgstr "Повинен бути список дійсних електронних адрес (розділений комами)."
 
-#: ./validators.py:48
+#: ./collective/easyform/validators.py:48
 msgid "Must be checked."
 msgstr "Має бути вибрано."
 
-#: ./validators.py:53
+#: ./collective/easyform/validators.py:53
 msgid "Must be unchecked."
 msgstr "Не має бути вибрано."
 
-#: ./browser/saveddata.pt:25
+#: ./collective/easyform/browser/saveddata.pt:25
 msgid "No adapters available."
 msgstr ""
 
-#: ./interfaces/actions.py:77
-#: ./interfaces/easyform.py:312
-#: ./interfaces/fields.py:117
+#: ./collective/easyform/interfaces/actions.py:77
+#: ./collective/easyform/interfaces/easyform.py:312
+#: ./collective/easyform/interfaces/fields.py:117
 msgid "Overrides"
 msgstr "Перевизначення"
 
-#: ./interfaces/fields.py:239
+#: ./collective/easyform/interfaces/fields.py:239
 msgid "Possible answers"
 msgstr ""
 
-#: ./interfaces/fields.py:231
+#: ./collective/easyform/interfaces/fields.py:231
 msgid "Possible questions"
 msgstr ""
 
-#: ./interfaces/savedata.py:19
+#: ./collective/easyform/interfaces/savedata.py:19
 msgid "Posting Date/Time"
 msgstr "Дата/час заповнення"
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Redirect to"
 msgstr "Перенаправити до"
 
-#: ./browser/view.py:224
+#: ./collective/easyform/browser/view.py:224
 msgid "Reset"
 msgstr "Відновити"
 
-#: ./interfaces/fields.py:201
+#: ./collective/easyform/interfaces/fields.py:201
 msgid "Rich Label"
 msgstr "Розширений напис"
 
-#: ./browser/fields.py:98
+#: ./collective/easyform/browser/fields.py:98
 msgid "Save"
 msgstr ""
 
-#: ./browser/saveddata_form.pt:9
+#: ./collective/easyform/browser/saveddata_form.pt:9
 msgid "Saved Data"
 msgstr ""
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "Saved data"
 msgstr "Збережені дані"
 
-#: ./browser/controlpanel.py:32
+#: ./collective/easyform/browser/controlpanel.py:32
 msgid "Set the default delimiter for CSV download."
 msgstr ""
 
-#: ./browser/controlpanel.py:39
+#: ./collective/easyform/browser/controlpanel.py:39
 msgid "Set the maximum filesize (in bytes) that users should be able to upload."
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Subject"
 msgstr ""
 
-#: ./interfaces/easyform.py:117
+#: ./collective/easyform/interfaces/easyform.py:117
 msgid "Thanks Page"
 msgstr "Сторінка подяки"
 
-#: ./browser/controlpanel.py:21
-#: ./profiles/default/registry.xml
+#: ./collective/easyform/browser/controlpanel.py:21
+#: ./collective/easyform/profiles/default/registry.xml
 msgid "These Fields are available for your forms."
 msgstr ""
 
-#: ./interfaces/fields.py:97
+#: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
 msgstr ""
 
-#: ./vocabularies.py:30
+#: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
 msgstr "Траверсити до"
 
-#: ./interfaces/fields.py:76
+#: ./collective/easyform/interfaces/fields.py:76
 msgid "Validators"
 msgstr "Валідатори"
 
-#: ./profiles/default/actions.xml
+#: ./collective/easyform/profiles/default/actions.xml
 msgid "View"
 msgstr ""
 
-#: ./default_schemata/fields_default.xml
+#: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr ""
 
 #. Default: "Reset"
-#: ./interfaces/easyform.py:34
+#: ./collective/easyform/interfaces/easyform.py:34
 msgid "default_resetLabel"
 msgstr ""
 
 #. Default: "Submit"
-#: ./interfaces/easyform.py:26
+#: ./collective/easyform/interfaces/easyform.py:26
 msgid "default_submitLabel"
 msgstr ""
 
 #. Default: "Thanks for your input."
-#: ./interfaces/easyform.py:50
+#: ./collective/easyform/interfaces/easyform.py:50
 msgid "default_thanksdescription"
 msgstr ""
 
 #. Default: "Thank You"
-#: ./interfaces/easyform.py:42
+#: ./collective/easyform/interfaces/easyform.py:42
 msgid "default_thankstitle"
 msgstr ""
 
 #. Default: "Mark this field as a value to be injected into the request form for use by action adapters and is not modifiable by or exposed to the client."
-#: ./interfaces/fields.py:174
+#: ./collective/easyform/interfaces/fields.py:174
 msgid "description_server_side_text"
 msgstr "Позначити це поле як значення, що буде вставлене у форму запиту, що використовуватиметься адаптерами дії, і не буде модифікуватись чи надаватись клієнту."
 
-#: ./browser/controlpanel.py:47
+#: ./collective/easyform/browser/controlpanel.py:47
 msgid "easyform Settings"
 msgstr ""
 
 #. Default: "${name} Header"
-#: ./interfaces/mailer.py:397
-#: ./interfaces/savedata.py:22
+#: ./collective/easyform/interfaces/mailer.py:397
+#: ./collective/easyform/interfaces/savedata.py:22
 msgid "extra_header"
 msgstr "${name} Заголовок"
 
 #. Default: "A TALES expression that will be called after the form issuccessfully validated, but before calling an action adapter (if any) or displaying a thanks page.Form input will be in the request.form dictionary.Leave empty if unneeded. The most common use of this field is to call a python scriptto clean up form input or to script an alternative action. Any value returned by the expression is ignored.PLEASE NOTE: errors in the evaluation of this expression willcause an error on form display."
-#: ./interfaces/easyform.py:406
+#: ./collective/easyform/interfaces/easyform.py:406
 #, fuzzy
 msgid "help_AfterValidationOverride_text"
 msgstr "TALES вираз, який буде викликано після успішної перевірки форми, але до виклику адаптера дії (якщо такий є), чи відображення сторінки подяки. Вміст форми буде у словнику request.form. Заповнювати поле не обов'язково. Найпоширеніше використання цього поля - для виклику python скрипта, що видаляє дані, введені в форму, або для додання альтернативної дії. Будь-яке значення, що поверне цей вираз, буде проігнороване. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be called when the form is displayed. Leave empty if unneeded. The most common use of this field is to call a python script that sets defaults for multiple fields by pre-populating request.form. Any value returned by the expression is ignored. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:386
+#: ./collective/easyform/interfaces/easyform.py:386
 msgid "help_OnDisplayOverride_text"
 msgstr "TALES вираз, який буде викликано при відображенні форми. Заповнювати поле не обов'язково. Найпоширеніше використання цього поля - це виклик python скрипта, що встановлює значення за замовчуванням для багатьох полів у request.form. Будь-яке значення, що поверне цей вираз, буде проігнороване. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: ./interfaces/easyform.py:249
+#: ./collective/easyform/interfaces/easyform.py:249
 msgid "help_autofocus"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the BCC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:498
+#: ./collective/easyform/interfaces/mailer.py:498
 msgid "help_bcc_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в список прихованих копій (BСС). Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як послідовність рядків. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the CC list. You are strongly cautioned against using unvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a sequence of strings. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:478
+#: ./collective/easyform/interfaces/mailer.py:478
 msgid "help_cc_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в список копій (СС). Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як послідовність рядків. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Check this to employ Cross-Site Request Forgery protection. Note that only HTTP Post actions will be allowed."
-#: ./interfaces/easyform.py:284
+#: ./collective/easyform/interfaces/easyform.py:284
 msgid "help_csrf"
 msgstr "Позначте, щоб застосувати захист від підробки міжсайтових запитів (Cross-Site Request Forgery protection). Пам'ятайте, що лише дії HTTP Post будуть дозволені."
 
 #. Default: "This field allows you to change default fieldset label."
-#: ./interfaces/easyform.py:259
+#: ./collective/easyform/interfaces/easyform.py:259
 msgid "help_default_fieldset_label_text"
 msgstr "Це поле дозволяє змінити заголовок набору полів за замовчуванням."
 
 #. Default: "The text will be displayed after the form fields."
-#: ./interfaces/easyform.py:107
+#: ./collective/easyform/interfaces/easyform.py:107
 msgid "help_epilogue_text"
 msgstr "Текст буде розміщено після полів форми."
 
 #. Default: "A TALES expression that will be evaluated to determine whether or not to execute this action. Leave empty if unneeded, and the action will be executed. Your expression should evaluate as a boolean; return True if you wish the action to execute. PLEASE NOTE: errors in the evaluation of this expression will  cause an error on form display."
-#: ./interfaces/actions.py:82
+#: ./collective/easyform/interfaces/actions.py:82
 #, fuzzy
 msgid "help_execcondition_text"
 msgstr "TALES вираз, що буде обчислюватися, щоб визначити - виконувати, чи не виконувати цю дію. Заповнювати поле не обов'язково. Якщо ви залишите поле пустим, дія буде виконуватись. Ваш вираз повинен обчислюватись як логічна змінна: повертає True, якщо ви хочете, щоб дія виконувалась. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: ./interfaces/fields.py:70
+#: ./collective/easyform/interfaces/fields.py:70
 msgid "help_field_widget"
 msgstr ""
 
 #. Default: "Check this to make the form redirect to an SSL-enabled version of itself (https://) if accessed via a non-SSL URL (http://).  In order to function properly, this requires a web server that has been configured to handle the HTTPS protocol on port 443 and forward it to Zope."
-#: ./interfaces/easyform.py:296
+#: ./collective/easyform/interfaces/easyform.py:296
 msgid "help_force_ssl"
 msgstr "Позначте, щоб форма переходила на свою безпечну версію з SSL протоколом (https://), якщо використовується звичайний URL (http://) без SSL протоколу. Для правильного функціонування, потрібен веб сервер, налаштований для обробки протоколу HTTPS на порті 443 і його перенаправлення на Zope."
 
-#: ./interfaces/easyform.py:242
+#: ./collective/easyform/interfaces/easyform.py:242
 msgid "help_form_tabbing"
 msgstr ""
 
 #. Default: "Use this field to override the form action attribute. Specify a URL to which the form will post. This will bypass form validation, success action adapter and thanks page."
-#: ./interfaces/easyform.py:372
+#: ./collective/easyform/interfaces/easyform.py:372
 msgid "help_formactionoverride_text"
 msgstr "Використовуйте це поле, щоб перевизначити властивість дії форми. Вкажіть URL-адресу, куди буде розміщена форма. Це обійде перевірку форми, адаптер успішної дії та сторінку подяки."
 
 #. Default: "Additional e-mail-header lines. Only use RFC822-compliant headers."
-#: ./interfaces/mailer.py:389
+#: ./collective/easyform/interfaces/mailer.py:389
 msgid "help_formmailer_additional_headers"
 msgstr "Додаткові рядки заголовка електронного листа. Використовуйте лише RFC822-сумісні заголовки."
 
 #. Default: "E-mail addresses which receive a blind carbon copy."
-#: ./interfaces/mailer.py:121
+#: ./collective/easyform/interfaces/mailer.py:121
 msgid "help_formmailer_bcc_recipients"
 msgstr "Адреси електронних пошт, які отримають приховані копії."
 
 #. Default: "Text used as the footer at bottom, delimited from the body by a dashed line."
-#: ./interfaces/mailer.py:225
+#: ./collective/easyform/interfaces/mailer.py:225
 msgid "help_formmailer_body_footer"
 msgstr "Текст, що буде відображатись у нижньому колонтитулі, відділений від основного тексту пунктирною лінією."
 
 #. Default: "Text appended to fields listed in mail-body"
-#: ./interfaces/mailer.py:210
+#: ./collective/easyform/interfaces/mailer.py:210
 msgid "help_formmailer_body_post"
 msgstr "Текст, що буде доданий до полів, перерахованих в основній частині електронного листа."
 
 #. Default: "Text prepended to fields listed in mail-body"
-#: ./interfaces/mailer.py:195
+#: ./collective/easyform/interfaces/mailer.py:195
 msgid "help_formmailer_body_pre"
 msgstr "Текст, що буде доданий перед полями, перерахованими в основній частині електронного листа."
 
 #. Default: "This is a Zope Page Template used for rendering of the mail-body. You don't need to modify it, but if you know TAL (Zope's Template Attribute Language) have the full power to customize your outgoing mails."
-#: ./interfaces/mailer.py:341
+#: ./collective/easyform/interfaces/mailer.py:341
 #, fuzzy
 msgid "help_formmailer_body_pt"
 msgstr "Це шаблон сторінки у Zope, що використовується для обробки електронного листа. Немає потреби його змінювати, хоча, якщо ви знайомі з  TAL (Template Attribute Language для Zope), то у вас є всі можливості для налаштування вихідних електронних повідомлень."
 
 #. Default: "Set the mime-type of the mail-body. Change this setting only if you know exactly what you are doing. Leave it blank for default behaviour."
-#: ./interfaces/mailer.py:356
+#: ./collective/easyform/interfaces/mailer.py:356
 msgid "help_formmailer_body_type"
 msgstr "Задайте mime тип основної частини електронного листа. Змінюйте налаштування лише тоді, коли ви дійсно впевнені в правильності своїх дій. Залишіть поле пустим для налаштувань за замовчуванням."
 
 #. Default: "E-mail addresses which receive a carbon copy."
-#: ./interfaces/mailer.py:108
+#: ./collective/easyform/interfaces/mailer.py:108
 msgid "help_formmailer_cc_recipients"
 msgstr "Адреси електронної пошти, які отримають копію листа."
 
 #. Default: "The recipients e-mail address."
-#: ./interfaces/mailer.py:77
+#: ./collective/easyform/interfaces/mailer.py:77
 msgid "help_formmailer_recipient_email"
 msgstr "Адреса електронної пошти отримувача."
 
 #. Default: "The full name of the recipient of the mailed form."
-#: ./interfaces/mailer.py:62
+#: ./collective/easyform/interfaces/mailer.py:62
 msgid "help_formmailer_recipient_fullname"
 msgstr "Повне ім'я отримувача електронного листа з формою."
 
 #. Default: "Choose a form field from which you wish to extract input for the Reply-To header. NOTE: You should activate e-mail address verification for the designated field."
-#: ./interfaces/mailer.py:134
+#: ./collective/easyform/interfaces/mailer.py:134
 msgid "help_formmailer_replyto_extract"
 msgstr "Виберіть поле форми, з якого будуть братися дані для заголовка листа-відповіді. ПРИМІТКА: Увімкніть перевірку адрес електронних пошт для цього поля."
 
 #. Default: "Subject line of message. This is used if you do not specify a subject field or if the field is empty."
-#: ./interfaces/mailer.py:165
+#: ./collective/easyform/interfaces/mailer.py:165
 msgid "help_formmailer_subject"
 msgstr "Тема повідомлення. Вона буде використана, якщо поле теми не вказане, або це поле пусте."
 
 #. Default: "Choose a form field from which you wish to extract input for the mail subject line."
-#: ./interfaces/mailer.py:181
+#: ./collective/easyform/interfaces/mailer.py:181
 msgid "help_formmailer_subject_extract"
 msgstr "Виберіть поле форми, з якого будуть братися дані для теми листа."
 
 #. Default: "Choose a form field from which you wish to extract input for the To header. If you choose anything other than \"None\", this will override the \"Recipient's \" e-mail address setting above. Be very cautious about allowing unguarded user input for this purpose."
-#: ./interfaces/mailer.py:92
+#: ./collective/easyform/interfaces/mailer.py:92
 #, fuzzy
 msgid "help_formmailer_to_extract"
 msgstr "Виберіть поле форми, з якого буде взята інформація для заголовка \"Кому\". Якщо ви виберете будь-що інше крім \"Жоден\", це перекриє налаштування \"Адреса електронної пошти отримувача\" вище. Будьте обережними з введенням цієї інформації."
 
 #. Default: "This override field allows you to insert content into the xhtml head. The typical use is to add custom CSS or JavaScript. Specify a TALES expression returning a string. The string will be inserted with no interpretation. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:426
+#: ./collective/easyform/interfaces/easyform.py:426
 msgid "help_headerInjection_text"
 msgstr "Це поле перевизначення дозволяє вставити вміст в xhtml-заголовок. Переважно поле використовується для додавання користувацького CSS або JavaScript коду. Вкажіть TALES вираз, що повертає рядок. Рядок буде вставлено ​​без перетворень. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Field is hidden"
-#: ./interfaces/fields.py:88
+#: ./collective/easyform/interfaces/fields.py:88
 msgid "help_hidden"
 msgstr ""
 
 #. Default: "Check this to display field titles for fields that received no input. Uncheck to leave fields with no input off the list."
-#: ./interfaces/easyform.py:167
+#: ./collective/easyform/interfaces/easyform.py:167
 msgid "help_includeEmpties_text"
 msgstr "Позначте для відображення назв незаповнених полів. Не позначайте і порожні поля не відображатимуться у списку."
 
 #. Default: "Check this to include titles for fields that received no input. Uncheck to leave fields with no input out of the e-mail."
-#: ./interfaces/mailer.py:269
+#: ./collective/easyform/interfaces/mailer.py:269
 msgid "help_mailEmpties_text"
 msgstr "Позначте для включення назв незаповнених полів. Не позначайте і порожні поля не відображатимуться в електронному листі."
 
 #. Default: "Check this to include input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/mailer.py:241
+#: ./collective/easyform/interfaces/mailer.py:241
 msgid "help_mailallfields_text"
 msgstr "Позначте, щоб вибрати вхідні дані для всіх полів (крім написів і файлових типів вмісту). При виборі цього пункту, всі нижче перечислені пункти будуть проігноровані."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the e-mail."
-#: ./interfaces/mailer.py:256
+#: ./collective/easyform/interfaces/mailer.py:256
 msgid "help_mailfields_text"
 msgstr "Виберіть поля, дані з яких будуть включені в електронний лист."
 
-#: ./interfaces/easyform.py:269
+#: ./collective/easyform/interfaces/easyform.py:269
 msgid "help_method"
 msgstr ""
 
 #. Default: "optional, sets the name attribute on the form container. can be used for form analytics"
-#: ./interfaces/easyform.py:233
+#: ./collective/easyform/interfaces/easyform.py:233
 msgid "help_name_attribute"
 msgstr ""
 
 #. Default: "This text will be displayed above the form fields."
-#: ./interfaces/easyform.py:99
+#: ./collective/easyform/interfaces/easyform.py:99
 msgid "help_prologue_text"
 msgstr "Цей текст буде відображатись над полями форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the recipient e-mail address. You are strongly cautioned against usingunvalidated data from the request for this purpose. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:457
+#: ./collective/easyform/interfaces/mailer.py:457
 #, fuzzy
 msgid "help_recipient_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в поле адреси електронної пошти отримувача. Не вводьте неперевірені дані із запиту. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: ./interfaces/easyform.py:227
+#: ./collective/easyform/interfaces/easyform.py:227
 msgid "help_reset_button"
 msgstr ""
 
 #. Default: "Pick any extra data you'd like saved with the form input."
-#: ./interfaces/savedata.py:72
+#: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
 msgstr "Виберіть додаткові дані, які будуть збережені разом із введеною в форму інформацією. "
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
-#: ./interfaces/savedata.py:60
+#: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
 msgstr "Виберіть поля, дані з яких будуть збережені. Якщо жодне поле не вибране, то зберігатимуться всі вхідні дані."
 
 #. Default: "Write your script here."
-#: ./interfaces/customscript.py:32
+#: ./collective/easyform/interfaces/customscript.py:32
 msgid "help_script_body"
 msgstr "Додайте ваш скрипт сюди."
 
 #. Default: "Role under which to run the script."
-#: ./interfaces/customscript.py:21
+#: ./collective/easyform/interfaces/customscript.py:21
 msgid "help_script_proxy"
 msgstr "Роль від якої запускатиметься скрипт."
 
 #. Default: "Check this to send a CSV file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:283
+#: ./collective/easyform/interfaces/mailer.py:283
 msgid "help_sendCSV_text"
 msgstr ""
 
 #. Default: "Check this to include the CSV/XLSX header in file attachments."
-#: ./interfaces/mailer.py:297
+#: ./collective/easyform/interfaces/mailer.py:297
 msgid "help_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Check this to send a XLSX file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:310
+#: ./collective/easyform/interfaces/mailer.py:310
 msgid "help_sendXLSX_text"
 msgstr ""
 
 #. Default: "Check this to send an XML file attachment containing the values filled out in the form."
-#: ./interfaces/mailer.py:325
+#: ./collective/easyform/interfaces/mailer.py:325
 msgid "help_sendXML_text"
 msgstr ""
 
 #. Default: "A TALES expression that will be evaluated to override the \"From\" header. Leave empty if unneeded. Your expression should evaluate as a string. Example: python:fields['replyto'] PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:438
+#: ./collective/easyform/interfaces/mailer.py:438
 #, fuzzy
 msgid "help_sender_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення заголовка \"Від кого\". Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Check this to display input for all fields (except label and file fields). If you check this, the choices in the pick box below will be ignored."
-#: ./interfaces/easyform.py:143
+#: ./collective/easyform/interfaces/easyform.py:143
 msgid "help_showallfields_text"
 msgstr "Позначте, щоб відображати вхідні дані для всіх полів (крім заголовків/написів і файлових типів вмісту). При виборі цього пункту, всі нижче перечислені пункти будуть проігноровані."
 
-#: ./interfaces/easyform.py:221
+#: ./collective/easyform/interfaces/easyform.py:221
 msgid "help_showcancel_text"
 msgstr ""
 
 #. Default: "Pick the fields whose inputs you'd like to display on the success page."
-#: ./interfaces/easyform.py:156
+#: ./collective/easyform/interfaces/easyform.py:156
 msgid "help_showfields_text"
 msgstr "Виберіть поля, дані з яких будуть відображатись на сторінці, що повідомлятиме про успішне заповнення форми."
 
 #. Default: "A TALES expression that will be evaluated to override any value otherwise entered for the e-mail subject header. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/mailer.py:419
+#: ./collective/easyform/interfaces/mailer.py:419
 msgid "help_subject_override_text"
 msgstr "TALES вираз, що буде обчислюватися для перевизначення будь-якого значення, введеного в поле заголовка електронного листа. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: ./interfaces/easyform.py:215
+#: ./collective/easyform/interfaces/easyform.py:215
 msgid "help_submitlabel_text"
 msgstr ""
 
 #. Default: "This override field allows you to change submit button label. The typical use is to set label with request parameters. Specify a TALES expression returning a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/easyform.py:444
+#: ./collective/easyform/interfaces/easyform.py:444
 msgid "help_submitlabeloverride_text"
 msgstr "Це поле перевизначення дозволяє змінити напис кнопки Надіслати. Переважно поле використовується для встановлення напису з параметрами запиту. Вкажіть TALES вираз, що повертає рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated when the formis displayed to get the field default value. Leave empty if unneeded. Your expression should evaluate as a string. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:123
+#: ./collective/easyform/interfaces/fields.py:123
 #, fuzzy
 msgid "help_tdefault_text"
 msgstr "TALES вираз, що буде обчислюватися, коли відображатиметься форма, щоб отримати значення поля за замовчуванням. Заповнювати поле не обов'язково. Ваш вираз повинен обчислюватись як рядок. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "A TALES expression that will be evaluated when the form is displayed to determine whether or not the field is enabled. Your expression should evaluate as True if the field should be included in the form, False if it should be omitted. Leave this expression field empty if unneeded: the field will be included. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:138
+#: ./collective/easyform/interfaces/fields.py:138
 msgid "help_tenabled_text"
 msgstr "TALES вираз, що буде обчислюватися коли відображатиметься форма, щоб визначити, чи включене поле. Ваш вираз повинен обчислюватись як True, якщо поле повинне бути включене в форму, False - якщо його треба пропустити. Заповнювати поле не обов'язково. Якщо залишити поле для виразу пустим, поле буде включене. ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
 #. Default: "Used in thanks page."
-#: ./interfaces/easyform.py:136
+#: ./collective/easyform/interfaces/easyform.py:136
 msgid "help_thanksdescription"
 msgstr "Використовується на сторінці подяки."
 
 #. Default: "The text will be displayed after the field inputs."
-#: ./interfaces/easyform.py:187
+#: ./collective/easyform/interfaces/easyform.py:187
 msgid "help_thanksepilogue_text"
 msgstr "Текст буде відображатись після інформації, вказаної в полі."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:351
+#: ./collective/easyform/interfaces/easyform.py:351
 msgid "help_thankspageoverride_text"
 msgstr "Використовуйте це поле замість призначення сторінки подяки, щоб визначити фінальну дію після виклику адаптера дії (якщо такий є). Переважно використовується для користувацького шаблону чи скрипту. Заповнювати поле не обов'язково. Вкажіть тип дії CMFFormController та аргумент, і доповніть типом дії для виконання (наприклад, \"redirect_to\" або \"traverse_to\") та TALES виразом. Наприклад, \"Redirect to\" і \"string:thanks-page\" переадресує на \"thanks-page\"."
 
 #. Default: "Use this field in place of a thanks-page designation to determine final action after calling your action adapter (if you have one). You would usually use this for a custom success template or script. Leave empty if unneeded. Otherwise, specify as you would a CMFFormController action type and argument, complete with type of action to execute (e.g., \"redirect_to\" or \"traverse_to\") and a TALES expression. For example, \"Redirect to\" and \"string:thanks-page\" would redirect to \"thanks-page\"."
-#: ./interfaces/easyform.py:330
+#: ./collective/easyform/interfaces/easyform.py:330
 msgid "help_thankspageoverrideaction_text"
 msgstr "Використовуйте це поле замість призначення сторінки подяки, щоб визначити фінальну дію після виклику адаптера дії (якщо такий є). Переважно використовується для користувацького шаблону чи скрипту. Заповнювати поле не обов'язково. Вкажіть тип дії CMFFormController та аргумент, і доповніть типом дії для виконання (наприклад, \"redirect_to\" або \"traverse_to\") та TALES виразом. Наприклад, \"Redirect to\" і \"string:thanks-page\" переадресує на \"thanks-page\"."
 
 #. Default: "This text will be displayed above the selected field inputs."
-#: ./interfaces/easyform.py:179
+#: ./collective/easyform/interfaces/easyform.py:179
 msgid "help_thanksprologue_text"
 msgstr "Текст буде відображатись над вибраними полями."
 
 #. Default: "A TALES expression that will be evaluated when the form is validated. Validate against 'value', which will contain the field input. Return False if valid; if not valid return a string error message. E.G., \"python: test(value=='eggs', False, 'input must be eggs')\" will require \"eggs\" for input. PLEASE NOTE: errors in the evaluation of this expression will cause an error on form display."
-#: ./interfaces/fields.py:156
+#: ./collective/easyform/interfaces/fields.py:156
 msgid "help_tvalidator_text"
 msgstr "TALES вираз, що буде обчислюватися після перевірки форми. Перевіряється ’значення’, яке буде містити дані введені в поле. Вернути False, якщо дані вірні, якщо не вірні, то вернути повідомлення про помилку. Наприклад, \"python: test(value=='eggs', False, 'input must be eggs')\" вимагатиме вводити \"eggs\". ПРИМІТКА: помилка в обчисленні цього виразу призведе до помилки при виведенні форми."
 
-#: ./interfaces/easyform.py:277
+#: ./collective/easyform/interfaces/easyform.py:277
 msgid "help_unload_protection"
 msgstr ""
 
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
-#: ./interfaces/savedata.py:86
+#: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
 msgstr "Чи відображати назви колонок в першому рядку завантажених даних?"
 
 #. Default: "Select the validators to use on this field"
-#: ./interfaces/fields.py:77
+#: ./collective/easyform/interfaces/fields.py:77
 msgid "help_userfield_validators"
 msgstr "Виберіть валідатори для цього поля."
 
 #. Default: "Pick any items from the HTTP headers that you'd like to insert as X- headers in the message."
-#: ./interfaces/mailer.py:373
+#: ./collective/easyform/interfaces/mailer.py:373
 msgid "help_xinfo_headers_text"
 msgstr "Виберіть будь-яку частину HTTP-заголовків, які будуть вставлені як Х-заголовки в повідомлення."
 
-#: ./browser/exportimport.py:46
+#: ./collective/easyform/browser/exportimport.py:46
 msgid "import"
 msgstr "Імпорт"
 
 #. Default: "After Validation Script"
-#: ./interfaces/easyform.py:403
+#: ./collective/easyform/interfaces/easyform.py:403
 msgid "label_AfterValidationOverride_text"
 msgstr "Скрипт після перевірки"
 
 #. Default: "Form Setup Script"
-#: ./interfaces/easyform.py:385
+#: ./collective/easyform/interfaces/easyform.py:385
 msgid "label_OnDisplayOverride_text"
 msgstr "Скрипт для налаштування форми"
 
 #. Default: "Enable focus on the first input"
-#: ./interfaces/easyform.py:248
+#: ./collective/easyform/interfaces/easyform.py:248
 msgid "label_autofocus"
 msgstr ""
 
 #. Default: "BCC Expression"
-#: ./interfaces/mailer.py:497
+#: ./collective/easyform/interfaces/mailer.py:497
 msgid "label_bcc_override_text"
 msgstr "Вираз для прихованої копії"
 
 #. Default: "CC Expression"
-#: ./interfaces/mailer.py:477
+#: ./collective/easyform/interfaces/mailer.py:477
 msgid "label_cc_override_text"
 msgstr "Вираз для копії"
 
 #. Default: "CSRF Protection"
-#: ./interfaces/easyform.py:283
+#: ./collective/easyform/interfaces/easyform.py:283
 msgid "label_csrf"
 msgstr "Захист від CSRF атак"
 
 #. Default: "Custom Script"
-#: ./actions.py:909
+#: ./collective/easyform/actions.py:909
 msgid "label_customscript_action"
 msgstr ""
 
 #. Default: "Custom Default Fieldset Label"
-#: ./interfaces/easyform.py:255
+#: ./collective/easyform/interfaces/easyform.py:255
 msgid "label_default_fieldset_label_text"
 msgstr "Користувацький заголовок стандартного набору полів"
 
 #. Default: "Download Format"
-#: ./interfaces/savedata.py:80
+#: ./collective/easyform/interfaces/savedata.py:80
 msgid "label_downloadformat_text"
 msgstr "Формат завантаження"
 
 #. Default: "Form Epilogue"
-#: ./interfaces/easyform.py:106
+#: ./collective/easyform/interfaces/easyform.py:106
 msgid "label_epilogue_text"
 msgstr "Епілог форми"
 
 #. Default: "Execution Condition"
-#: ./interfaces/actions.py:81
+#: ./collective/easyform/interfaces/actions.py:81
 msgid "label_execcondition_text"
 msgstr "Умова для виконання"
 
 #. Default: "Field Widget"
-#: ./interfaces/fields.py:69
+#: ./collective/easyform/interfaces/fields.py:69
 msgid "label_field_widget"
 msgstr "Віджет поля"
 
 #. Default: "Force SSL connection"
-#: ./interfaces/easyform.py:295
+#: ./collective/easyform/interfaces/easyform.py:295
 msgid "label_force_ssl"
 msgstr "Форсувати SSL з’єднання"
 
 #. Default: "Turn fieldsets to tabs"
-#: ./interfaces/easyform.py:241
+#: ./collective/easyform/interfaces/easyform.py:241
 msgid "label_form_tabbing"
 msgstr "Перетворити набори полів на таби"
 
 #. Default: "Custom Form Action"
-#: ./interfaces/easyform.py:371
+#: ./collective/easyform/interfaces/easyform.py:371
 msgid "label_formactionoverride_text"
 msgstr "Користувацька дія для форми"
 
 #. Default: "Additional Headers"
-#: ./interfaces/mailer.py:388
+#: ./collective/easyform/interfaces/mailer.py:388
 msgid "label_formmailer_additional_headers"
 msgstr "Додаткові заголовки"
 
 #. Default: "BCC Recipients"
-#: ./interfaces/mailer.py:120
+#: ./collective/easyform/interfaces/mailer.py:120
 msgid "label_formmailer_bcc_recipients"
 msgstr "Отримувачі прихованої копії"
 
 #. Default: "Body (signature)"
-#: ./interfaces/mailer.py:224
+#: ./collective/easyform/interfaces/mailer.py:224
 msgid "label_formmailer_body_footer"
 msgstr "Основна частина (підпис)"
 
 #. Default: "Body (appended)"
-#: ./interfaces/mailer.py:209
+#: ./collective/easyform/interfaces/mailer.py:209
 msgid "label_formmailer_body_post"
 msgstr "Основна частина (прикріплено після)"
 
 #. Default: "Body (prepended)"
-#: ./interfaces/mailer.py:194
+#: ./collective/easyform/interfaces/mailer.py:194
 msgid "label_formmailer_body_pre"
 msgstr "Основна частина (прикріплено до)"
 
 #. Default: "Mail-Body Template"
-#: ./interfaces/mailer.py:340
+#: ./collective/easyform/interfaces/mailer.py:340
 msgid "label_formmailer_body_pt"
 msgstr "Шаблон основної частини листа"
 
 #. Default: "Mail Format"
-#: ./interfaces/mailer.py:355
+#: ./collective/easyform/interfaces/mailer.py:355
 msgid "label_formmailer_body_type"
 msgstr "Формат електронного листа"
 
 #. Default: "CC Recipients"
-#: ./interfaces/mailer.py:107
+#: ./collective/easyform/interfaces/mailer.py:107
 msgid "label_formmailer_cc_recipients"
 msgstr "Отримувачі копії"
 
 #. Default: "Recipient's e-mail address"
-#: ./interfaces/mailer.py:74
+#: ./collective/easyform/interfaces/mailer.py:74
 msgid "label_formmailer_recipient_email"
 msgstr "Адреса електронної пошти отримувача"
 
 #. Default: "Recipient's full name"
-#: ./interfaces/mailer.py:59
+#: ./collective/easyform/interfaces/mailer.py:59
 msgid "label_formmailer_recipient_fullname"
 msgstr "Повне ім'я отримувача"
 
 #. Default: "Extract Reply-To From"
-#: ./interfaces/mailer.py:133
+#: ./collective/easyform/interfaces/mailer.py:133
 msgid "label_formmailer_replyto_extract"
 msgstr "Взяти Відповісти-Кому з"
 
 #. Default: "Subject"
-#: ./interfaces/mailer.py:164
+#: ./collective/easyform/interfaces/mailer.py:164
 msgid "label_formmailer_subject"
 msgstr "Тема"
 
 #. Default: "Extract Subject From"
-#: ./interfaces/mailer.py:180
+#: ./collective/easyform/interfaces/mailer.py:180
 msgid "label_formmailer_subject_extract"
 msgstr "Взяти Тему з"
 
 #. Default: "Extract Recipient From"
-#: ./interfaces/mailer.py:91
+#: ./collective/easyform/interfaces/mailer.py:91
 msgid "label_formmailer_to_extract"
 msgstr "Взяти Отримувача з"
 
 #. Default: "HCaptcha"
-#: ./fields.py:234
+#: ./collective/easyform/fields.py:234
 msgid "label_hcaptcha_field"
 msgstr ""
 
 #. Default: "Header Injection"
-#: ./interfaces/easyform.py:425
+#: ./collective/easyform/interfaces/easyform.py:425
 msgid "label_headerInjection_text"
 msgstr "Вставка заголовку"
 
 #. Default: "Hidden"
-#: ./interfaces/fields.py:87
+#: ./collective/easyform/interfaces/fields.py:87
 msgid "label_hidden"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/easyform.py:166
+#: ./collective/easyform/interfaces/easyform.py:166
 msgid "label_includeEmpties_text"
 msgstr "Включати пусті поля"
 
 #. Default: "Label"
-#: ./fields.py:209
+#: ./collective/easyform/fields.py:209
 msgid "label_label_field"
 msgstr "Напис"
 
 #. Default: "Likert"
-#: ./fields.py:285
+#: ./collective/easyform/fields.py:285
 msgid "label_likert_field"
 msgstr ""
 
 #. Default: "Include Empties"
-#: ./interfaces/mailer.py:268
+#: ./collective/easyform/interfaces/mailer.py:268
 msgid "label_mailEmpties_text"
 msgstr "Включати пусті поля"
 
 #. Default: "Include All Fields"
-#: ./interfaces/mailer.py:240
+#: ./collective/easyform/interfaces/mailer.py:240
 msgid "label_mailallfields_text"
 msgstr "Включати всі поля"
 
 #. Default: "Mailer"
-#: ./actions.py:904
+#: ./collective/easyform/actions.py:904
 msgid "label_mailer_action"
 msgstr ""
 
 #. Default: "Show Responses"
-#: ./interfaces/mailer.py:255
+#: ./collective/easyform/interfaces/mailer.py:255
 msgid "label_mailfields_text"
 msgstr "Показати відповіді"
 
 #. Default: "Form method"
-#: ./interfaces/easyform.py:268
+#: ./collective/easyform/interfaces/easyform.py:268
 msgid "label_method"
 msgstr "Метод форми"
 
 #. Default: "Name attribute"
-#: ./interfaces/easyform.py:232
+#: ./collective/easyform/interfaces/easyform.py:232
 msgid "label_name_attribute"
 msgstr ""
 
 #. Default: "NorobotCaptcha"
-#: ./fields.py:245
+#: ./collective/easyform/fields.py:245
 msgid "label_norobot_field"
 msgstr ""
 
 #. Default: "Form Prologue"
-#: ./interfaces/easyform.py:98
+#: ./collective/easyform/interfaces/easyform.py:98
 msgid "label_prologue_text"
 msgstr "Пролог форми"
 
 #. Default: "ReCaptcha"
-#: ./fields.py:224
+#: ./collective/easyform/fields.py:224
 msgid "label_recaptcha_field"
 msgstr "ReCaptcha"
 
 #. Default: "Recipient Expression"
-#: ./interfaces/mailer.py:456
+#: ./collective/easyform/interfaces/mailer.py:456
 msgid "label_recipient_override_text"
 msgstr "Вираз для Отримувача"
 
 #. Default: "Reset Button Label"
-#: ./interfaces/easyform.py:226
+#: ./collective/easyform/interfaces/easyform.py:226
 msgid "label_reset_button"
 msgstr "Напис кнопки скидання"
 
 #. Default: "Rich Label"
-#: ./fields.py:211
+#: ./collective/easyform/fields.py:211
 msgid "label_richlabel_field"
 msgstr "Розширений напис"
 
 #. Default: "Save Data"
-#: ./actions.py:914
+#: ./collective/easyform/actions.py:914
 msgid "label_savedata_action"
 msgstr ""
 
 #. Default: "Extra Data"
-#: ./interfaces/savedata.py:71
+#: ./collective/easyform/interfaces/savedata.py:71
 msgid "label_savedataextra_text"
 msgstr "Додаткові дані"
 
 #. Default: "Saved Fields"
-#: ./interfaces/savedata.py:59
+#: ./collective/easyform/interfaces/savedata.py:59
 msgid "label_savefields_text"
 msgstr "Збережені поля"
 
 #. Default: "Script body"
-#: ./interfaces/customscript.py:31
+#: ./collective/easyform/interfaces/customscript.py:31
 msgid "label_script_body"
 msgstr "Текст скрипта"
 
 #. Default: "Proxy role"
-#: ./interfaces/customscript.py:20
+#: ./collective/easyform/interfaces/customscript.py:20
 msgid "label_script_proxy"
 msgstr "Проксі роль"
 
 #. Default: "Send CSV data attachment"
-#: ./interfaces/mailer.py:282
+#: ./collective/easyform/interfaces/mailer.py:282
 msgid "label_sendCSV_text"
 msgstr ""
 
 #. Default: "Include header in attached CSV/XLSX data"
-#: ./interfaces/mailer.py:296
+#: ./collective/easyform/interfaces/mailer.py:296
 msgid "label_sendWithHeader_text"
 msgstr ""
 
 #. Default: "Send XLSX data attachment"
-#: ./interfaces/mailer.py:309
+#: ./collective/easyform/interfaces/mailer.py:309
 msgid "label_sendXLSX_text"
 msgstr ""
 
 #. Default: "Send XML data attachment"
-#: ./interfaces/mailer.py:324
+#: ./collective/easyform/interfaces/mailer.py:324
 msgid "label_sendXML_text"
 msgstr ""
 
 #. Default: "Sender Expression"
-#: ./interfaces/mailer.py:437
+#: ./collective/easyform/interfaces/mailer.py:437
 msgid "label_sender_override_text"
 msgstr "Вираз для Відправника"
 
 #. Default: "Server-Side Variable"
-#: ./interfaces/fields.py:173
+#: ./collective/easyform/interfaces/fields.py:173
 msgid "label_server_side_text"
 msgstr "Змінна для серверної сторони"
 
 #. Default: "Show All Fields"
-#: ./interfaces/easyform.py:142
+#: ./collective/easyform/interfaces/easyform.py:142
 msgid "label_showallfields_text"
 msgstr "Показувати всі поля"
 
 #. Default: "Show Reset Button"
-#: ./interfaces/easyform.py:220
+#: ./collective/easyform/interfaces/easyform.py:220
 msgid "label_showcancel_text"
 msgstr "Показувати кнопку скидання"
 
 #. Default: "Show Responses"
-#: ./interfaces/easyform.py:155
+#: ./collective/easyform/interfaces/easyform.py:155
 msgid "label_showfields_text"
 msgstr "Показувати відповіді"
 
 #. Default: "Subject Expression"
-#: ./interfaces/mailer.py:418
+#: ./collective/easyform/interfaces/mailer.py:418
 msgid "label_subject_override_text"
 msgstr "Вираз для Теми"
 
 #. Default: "Submit Button Label"
-#: ./interfaces/easyform.py:214
+#: ./collective/easyform/interfaces/easyform.py:214
 msgid "label_submitlabel_text"
 msgstr "Напис кнопки Надіслати"
 
 #. Default: "Custom Submit Button Label"
-#: ./interfaces/easyform.py:441
+#: ./collective/easyform/interfaces/easyform.py:441
 msgid "label_submitlabeloverride_text"
 msgstr "Користувацький напис кнопки Надіслати"
 
 #. Default: "Default Expression"
-#: ./interfaces/fields.py:122
+#: ./collective/easyform/interfaces/fields.py:122
 msgid "label_tdefault_text"
 msgstr "Вираз за замовчуванням"
 
 #. Default: "Enabling Expression"
-#: ./interfaces/fields.py:137
+#: ./collective/easyform/interfaces/fields.py:137
 msgid "label_tenabled_text"
 msgstr ""
 
 #. Default: "Thanks summary"
-#: ./interfaces/easyform.py:135
+#: ./collective/easyform/interfaces/easyform.py:135
 msgid "label_thanksdescription"
 msgstr "Короткий опис сторінки подяки"
 
 #. Default: "Thanks Epilogue"
-#: ./interfaces/easyform.py:186
+#: ./collective/easyform/interfaces/easyform.py:186
 msgid "label_thanksepilogue_text"
 msgstr "Епілог сторінки подяки"
 
 #. Default: "Custom Success Action"
-#: ./interfaces/easyform.py:350
+#: ./collective/easyform/interfaces/easyform.py:350
 msgid "label_thankspageoverride_text"
 msgstr ""
 
 #. Default: "Custom Success Action Type"
-#: ./interfaces/easyform.py:326
+#: ./collective/easyform/interfaces/easyform.py:326
 msgid "label_thankspageoverrideaction_text"
 msgstr ""
 
 #. Default: "Thanks Prologue"
-#: ./interfaces/easyform.py:178
+#: ./collective/easyform/interfaces/easyform.py:178
 msgid "label_thanksprologue_text"
 msgstr "Пролог сторінки подяки"
 
 #. Default: "Thanks title"
-#: ./interfaces/easyform.py:130
+#: ./collective/easyform/interfaces/easyform.py:130
 msgid "label_thankstitle"
 msgstr "Назва сторінки подяки"
 
 #. Default: "Custom Validator"
-#: ./interfaces/fields.py:155
+#: ./collective/easyform/interfaces/fields.py:155
 msgid "label_tvalidator_text"
 msgstr "Додатковий валідатор"
 
 #. Default: "Unload protection"
-#: ./interfaces/easyform.py:276
+#: ./collective/easyform/interfaces/easyform.py:276
 msgid "label_unload_protection"
 msgstr ""
 
 #. Default: "Include Column Names"
-#: ./interfaces/savedata.py:85
+#: ./collective/easyform/interfaces/savedata.py:85
 msgid "label_usecolumnnames_text"
 msgstr "Включати назви колонок"
 
 #. Default: "HTTP Headers"
-#: ./interfaces/mailer.py:372
+#: ./collective/easyform/interfaces/mailer.py:372
 msgid "label_xinfo_headers_text"
 msgstr "HTTP Заголовки"
 
-#: ./browser/view.py:452
+#: ./collective/easyform/browser/view.py:452
 msgid "msg_file_not_allowed"
 msgstr ""
 
-#: ./browser/view.py:443
+#: ./collective/easyform/browser/view.py:443
 msgid "msg_file_too_big"
 msgstr ""
 
 #. Default: "The saved data of ${formname} stored in the adapter ${adapter}"
-#: ./browser/saveddata_form.pt:14
+#: ./collective/easyform/browser/saveddata_form.pt:14
 msgid "saveddata_form_description"
 msgstr ""
 
 #. Default: "Comma-Separated Values"
-#: ./vocabularies.py:79
+#: ./collective/easyform/vocabularies.py:79
 msgid "vocabulary_csv_text"
 msgstr "Значення, розділені комою"
 
 #. Default: "Posting Date/Time"
-#: ./vocabularies.py:67
+#: ./collective/easyform/vocabularies.py:67
 msgid "vocabulary_postingdt_text"
 msgstr "Дата і час відправлення"
 
 #. Default: "Tab-Separated Values"
-#: ./vocabularies.py:78
+#: ./collective/easyform/vocabularies.py:78
 msgid "vocabulary_tsv_text"
 msgstr "Значення, розділені табуляцією"
 
 #. Default: "XLSX"
-#: ./vocabularies.py:84
+#: ./collective/easyform/vocabularies.py:84
 msgid "vocabulary_xlsx_text"
 msgstr ""


### PR DESCRIPTION
Add a checkbox to disable autofocus on the first input. It is enabled by default as is the default in Dexterity forms so it should not break anything.