### PR TITLE
Use batching on the saved data page.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 4.2.2 (unreleased)
 ------------------
 
+- Use batching on the saved data page.
+  [maurits]
+
 - Pin version `Products.validation>=3.0.0`
   [petschki]
 

--- a/src/collective/easyform/browser/actions.py
+++ b/src/collective/easyform/browser/actions.py
@@ -150,6 +150,10 @@ class SavedDataForm(crud.CrudForm):
         if ExtraData:
             return field.Fields(IExtraData).select(*ExtraData)
 
+    @property
+    def batch_size(self):
+        return int(self.request.form.get("batch_size", 10))
+
     def get_items(self):
         return [
             (key, DataWrapper(key, value, self.context))

--- a/src/collective/easyform/browser/actions.py
+++ b/src/collective/easyform/browser/actions.py
@@ -150,9 +150,6 @@ class SavedDataForm(crud.CrudForm):
         if ExtraData:
             return field.Fields(IExtraData).select(*ExtraData)
 
-    @property
-    def batch_size(self):
-        return int(self.request.form.get("batch_size", 10))
 
     def get_items(self):
         return [
@@ -204,6 +201,8 @@ class SavedDataFormWrapper(layout.FormWrapper):
             else:
                 self.context.field.download(self.request.response)
             return u""
+        if hasattr(self.context.field, 'BatchSize'):
+            self.form_instance.batch_size = self.context.field.BatchSize
         return super(SavedDataFormWrapper, self).__call__()
 
 

--- a/src/collective/easyform/interfaces/savedata.py
+++ b/src/collective/easyform/interfaces/savedata.py
@@ -91,3 +91,13 @@ class ISaveData(IAction):
         default=True,
         required=False,
     )
+    BatchSize = zope.schema.Int(
+        title=_(u"label_batch_size", default=u"Batch size"),
+        description=_(
+            u"batch_size_text",
+            default=u"Define a batch size. Leave blank or set to 0 to disable batching in @@data view.",
+        ),
+        default=10,
+        min=0,
+        required=False,
+    )

--- a/src/collective/easyform/locales/collective.easyform.pot
+++ b/src/collective/easyform/locales/collective.easyform.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -33,7 +33,7 @@ msgstr ""
 msgid "Actions Model"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr ""
 
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr ""
 
@@ -96,11 +96,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr ""
 
@@ -261,6 +261,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -623,6 +628,11 @@ msgstr ""
 #. Default: "Form Setup Script"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
+msgstr ""
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
 msgstr ""
 
 #. Default: "BCC Expression"

--- a/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/de/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2017-01-20 09:48+0000\n"
 "Last-Translator: Johannes Raggam <raggam-nl@adm.at>\n"
 "Language-Team: \n"
@@ -32,7 +32,7 @@ msgstr "Art der Aktion"
 msgid "Actions Model"
 msgstr "Aktionsmodell"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Eine neue Aktion hinzufügen"
 
@@ -67,7 +67,7 @@ msgstr "Das CSV Trennzeichen muss angegeben werden."
 msgid "Choose an adapter."
 msgstr "Wählen Sie einen Adapter aus."
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Alles löschen"
 
@@ -95,11 +95,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Aktion '${fieldname}' bearbeiten"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "XML Aktionsmodell bearbeiten"
 
@@ -260,6 +260,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -623,6 +628,11 @@ msgstr "Script nach der Validierung"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Script zum Formular Setup"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/en/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgstr ""
 msgid "Actions Model"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr ""
 
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr ""
 
@@ -93,11 +93,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr ""
 
@@ -258,6 +258,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -620,6 +625,11 @@ msgstr ""
 #. Default: "Form Setup Script"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
+msgstr ""
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
 msgstr ""
 
 #. Default: "BCC Expression"

--- a/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/es/LC_MESSAGES/collective.easyform.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2023-02-13 03:30-0400\n"
 "Last-Translator: Leonardo J. Caballero G. <leonardocaballero@gmail.com>\n"
 "Language-Team: ES <LL@li.org>\n"
@@ -36,7 +36,7 @@ msgstr "Tipo de Acción"
 msgid "Actions Model"
 msgstr "Modelo de Acción"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Añadir nueva acción"
 
@@ -71,7 +71,7 @@ msgstr "El delimitador CSV es obligatorio."
 msgid "Choose an adapter."
 msgstr "Elige un adaptador."
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Limpiar"
 
@@ -99,11 +99,11 @@ msgstr "Entrada de formulario de correos electrónicos"
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar acción '${fieldname}'"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Editar XML de Modelo de Acción"
 
@@ -265,6 +265,11 @@ msgstr "Vista"
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Su dirección de correo electrónico"
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
+msgstr ""
 
 #. Default: "Reset"
 #: ./collective/easyform/interfaces/easyform.py:34
@@ -628,6 +633,11 @@ msgstr "Script post-validación"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de preparación del formulario"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/eu/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2017-10-22 16:42+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -32,7 +32,7 @@ msgstr "Akzio mota"
 msgid "Actions Model"
 msgstr "Akzioen eredua"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Akzio berria gehitu"
 
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Guztiak ezabatu"
 
@@ -95,11 +95,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "'${fieldname}' akzioa aldatu"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Akzioen XML eredua editatu"
 
@@ -260,6 +260,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -625,6 +630,11 @@ msgstr "Balidazioaren osteko scripta"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Formularioa ezartzeko scripta"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/locales/fr/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/fr/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,7 +30,7 @@ msgstr "Type d'action"
 msgid "Actions Model"
 msgstr "Modèle des actions"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Ajouter une nouvelle action"
 
@@ -65,7 +65,7 @@ msgstr "Le délimiteur CSV est requis."
 msgid "Choose an adapter."
 msgstr "Choisissez un élément."
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Effacer tout"
 
@@ -93,11 +93,11 @@ msgstr "Envoie par courriel les réponses au formulaire"
 msgid "EasyForm"
 msgstr "Formulaire"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Editer l'action '${fieldname}'"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Editer le modèle XML des actions"
 
@@ -259,6 +259,11 @@ msgstr "Voir"
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Votre adresse courriel"
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
+msgstr ""
 
 #. Default: "Reset"
 #: ./collective/easyform/interfaces/easyform.py:34
@@ -623,6 +628,11 @@ msgstr "Script post-validation"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Script de configuration du formulaire"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2014-05-06 16.00+0000\n"
 "Last-Translator: Giorgio Borelli\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -31,7 +31,7 @@ msgstr "Tipo di azione"
 msgid "Actions Model"
 msgstr "Modello azioni"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Aggiungi azione"
 
@@ -66,7 +66,7 @@ msgstr "Il separatore per il CSV è obbligatorio"
 msgid "Choose an adapter."
 msgstr "Scegli un adattatore"
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Cancella i dati salvati"
 
@@ -94,11 +94,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Modifica l'azione '${fieldname}'"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Modifica l'XML delle azioni"
 
@@ -259,6 +259,11 @@ msgstr "Vista"
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -621,6 +626,11 @@ msgstr ""
 #. Default: "Form Setup Script"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
+msgstr ""
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
 msgstr ""
 
 #. Default: "BCC Expression"

--- a/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/it/LC_MESSAGES/collective.easyform.po
@@ -76,7 +76,7 @@ msgstr ""
 
 #: ./collective/easyform/interfaces/fields.py:108
 msgid "Define additional CSS class for this field here. This allowes for formating individual fields via CSS."
-msgstr ""
+msgstr "Definisci qui una classe CSS addizionale per questo campo. Questo serve a formattare individualmente un campo via CSS."
 
 #: ./collective/easyform/profiles/default/actions.xml
 msgid "Define form actions"
@@ -124,7 +124,7 @@ msgstr "Esporta"
 
 #: ./collective/easyform/interfaces/fields.py:94
 msgid "Field depends on"
-msgstr ""
+msgstr "Il campo dipende da"
 
 #: ./collective/easyform/interfaces/easyform.py:90
 msgid "Fields Model"
@@ -243,7 +243,7 @@ msgstr "Questi campi sono disponibili per le tue form"
 
 #: ./collective/easyform/interfaces/fields.py:97
 msgid "This is using the pat-depends from patternslib, all options are supported. Please read the <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> for options."
-msgstr ""
+msgstr "Utilizza pat-depends da patternslib, tutte le opzioni sono supportate. Si prega di leggere <a href=\"https://patternslib.com/demos/depends\" target=\"_blank\">pat-depends documentations</a> per le opzioni"
 
 #: ./collective/easyform/vocabularies.py:30
 msgid "Traverse to"
@@ -264,7 +264,7 @@ msgstr ""
 #. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
 #: ./collective/easyform/interfaces/savedata.py:96
 msgid "batch_size_text"
-msgstr ""
+msgstr "Definisci in numero di elementi per pagina. Lascia in bianco o impostalo a 0 per disabilitare la paginazione nella vista @@data"
 
 #. Default: "Reset"
 #: ./collective/easyform/interfaces/easyform.py:34
@@ -485,12 +485,12 @@ msgstr ""
 #. Default: "Pick any extra data you'd like saved with the form input."
 #: ./collective/easyform/interfaces/savedata.py:72
 msgid "help_savedataextra_text"
-msgstr ""
+msgstr "Scegli ogni altro dato extra che desideri salvare con il modulo di input."
 
 #. Default: "Pick the fields whose inputs you'd like to include in the saved data. If empty, all fields will be saved."
 #: ./collective/easyform/interfaces/savedata.py:60
 msgid "help_savefields_text"
-msgstr ""
+msgstr "Scegli i campi il cui inserimento desideri includere nei dati salvati. Se vuoto, tutti i campi saranno salvati."
 
 #. Default: "Write your script here."
 #: ./collective/easyform/interfaces/customscript.py:32
@@ -602,7 +602,7 @@ msgstr ""
 #. Default: "Do you wish to have column names on the first line of downloaded input?"
 #: ./collective/easyform/interfaces/savedata.py:86
 msgid "help_usecolumnnames_text"
-msgstr ""
+msgstr "Desideri avere i nomi delle colonne sulla prima linea degli input scaricati?"
 
 #. Default: "Select the validators to use on this field"
 #: ./collective/easyform/interfaces/fields.py:77

--- a/src/collective/easyform/locales/ja/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/ja/LC_MESSAGES/collective.easyform.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2021-03-31 11:45 +0900\n"
 "Last-Translator: Manabu TERADA <terada@cmscom.jp>\n"
 "Language-Team: None\n"
@@ -40,7 +40,7 @@ msgid "Actions Model"
 msgstr "アクションモデル"
 
 # Define form actions→「アクションを編集」右上ボタン
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "新規アクションを追加"
 
@@ -80,7 +80,7 @@ msgid "Choose an adapter."
 msgstr "アダプターを選択してください"
 
 # セーブデータ内など
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "全件削除"
 
@@ -112,13 +112,13 @@ msgid "EasyForm"
 msgstr "EasyForm"
 
 # Define form actions→「actionsを編集」
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "‘${fieldname}‘のアクションを編集"
 
 # 開発者に問い合わせ（何をやっているのか？）
 # Define form actions→actionsを編集→右下ボタン
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr " XML アクションズモデルを編集"
 
@@ -303,6 +303,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 # Easyform最初のページ下ボタン？
@@ -756,6 +761,11 @@ msgstr "バリデーション後のスクリプト"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "フォームセットアップスクリプト"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 # 開発者に何を行うものなのか確認
 # actions を編集⇒MailerのSettings⇒Overrides

--- a/src/collective/easyform/locales/nl/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/nl/LC_MESSAGES/collective.easyform.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: plone 5-buildout\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2021-06-02 16:11+0200\n"
 "Last-Translator: Thibaut Born <thibaut.born@kuleuven.be>\n"
 "Language-Team: Dutch\n"
@@ -34,7 +34,7 @@ msgstr "Type actie"
 msgid "Actions Model"
 msgstr "Actiemodel"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Voeg nieuwe actie toe"
 
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Choose an adapter."
 msgstr "Kies een adapter"
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Wis alles"
 
@@ -97,11 +97,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Bewerk '${fieldname}' actie"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Bewerk XML actiemodel"
 
@@ -263,6 +263,11 @@ msgstr ""
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
 msgstr "Jouw e-mailadres"
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
+msgstr ""
 
 #. Default: "Reset"
 #: ./collective/easyform/interfaces/easyform.py:34
@@ -627,6 +632,11 @@ msgstr "Script na validatie"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Formulier opstart script"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/pt_BR/LC_MESSAGES/collective.easyform.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2019-11-28 17:09+0100\n"
 "Last-Translator: Érico Andrei <ericof@plone.org>\n"
 "Language-Team: \n"
@@ -30,7 +30,7 @@ msgstr "Tipo de ação"
 msgid "Actions Model"
 msgstr "Modelo de ação"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Adicionar nova ação"
 
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Limpar tudo"
 
@@ -93,11 +93,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr "Formulário"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Editar ação '${fieldname}'"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Editar o XML do modelo de ação"
 
@@ -258,6 +258,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -623,6 +628,11 @@ msgstr "Script pós-validação"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Script para configuração do formulário"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
+++ b/src/collective/easyform/locales/uk/LC_MESSAGES/collective.easyform.po
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: collective.easyform\n"
-"POT-Creation-Date: 2024-12-09 14:13+0000\n"
+"POT-Creation-Date: 2024-12-10 17:27+0000\n"
 "PO-Revision-Date: 2015-10-13 11:16+0200\n"
 "Last-Translator: Zoriana Zaiats <sorenabell@quintagroup.com>\n"
 "Language-Team: Ukrainian <support@quintagroup.com>\n"
@@ -33,7 +33,7 @@ msgstr "Тип дії"
 msgid "Actions Model"
 msgstr "Модель дій"
 
-#: ./collective/easyform/browser/actions.py:292
+#: ./collective/easyform/browser/actions.py:295
 msgid "Add new action"
 msgstr "Додати нову дію"
 
@@ -68,7 +68,7 @@ msgstr ""
 msgid "Choose an adapter."
 msgstr ""
 
-#: ./collective/easyform/browser/actions.py:175
+#: ./collective/easyform/browser/actions.py:176
 msgid "Clear all"
 msgstr "Очистити все"
 
@@ -96,11 +96,11 @@ msgstr ""
 msgid "EasyForm"
 msgstr "EasyForm"
 
-#: ./collective/easyform/browser/actions.py:355
+#: ./collective/easyform/browser/actions.py:358
 msgid "Edit Action '${fieldname}'"
 msgstr "Редагувати дію '${fieldname}'"
 
-#: ./collective/easyform/browser/actions.py:360
+#: ./collective/easyform/browser/actions.py:363
 msgid "Edit XML Actions Model"
 msgstr "Редагувати XML модель дій"
 
@@ -261,6 +261,11 @@ msgstr ""
 
 #: ./collective/easyform/default_schemata/fields_default.xml
 msgid "Your E-Mail Address"
+msgstr ""
+
+#. Default: "Define a batch size. Leave blank or set to 0 to disable batching in @@data view."
+#: ./collective/easyform/interfaces/savedata.py:96
+msgid "batch_size_text"
 msgstr ""
 
 #. Default: "Reset"
@@ -631,6 +636,11 @@ msgstr "Скрипт після перевірки"
 #: ./collective/easyform/interfaces/easyform.py:377
 msgid "label_OnDisplayOverride_text"
 msgstr "Скрипт для налаштування форми"
+
+#. Default: "Batch size"
+#: ./collective/easyform/interfaces/savedata.py:95
+msgid "label_batch_size"
+msgstr ""
 
 #. Default: "BCC Expression"
 #: ./collective/easyform/interfaces/mailer.py:497

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -6,6 +6,7 @@
 from AccessControl.unauthorized import Unauthorized
 from collective.easyform.api import get_actions
 from collective.easyform.api import get_schema
+from collective.easyform.api import set_actions
 from collective.easyform.interfaces import ISaveData
 from collective.easyform.tests import base
 from os.path import dirname
@@ -652,10 +653,12 @@ class SaverIntegrationTestCase(base.EasyFormFunctionalTestCase):
         self.browser.addHeader(
             "Authorization", "Basic " + SITE_OWNER_NAME + ":" + SITE_OWNER_PASSWORD
         )
+        # Make sure we have an email address so the mailer action works.
+        api.portal.set_registry_record("plone.email_from_address", "to@example.org")
         self.createSaver()
 
     def createSaver(self):
-        """Creates FormCustomScript object"""
+        """Creates SaveData object"""
         # 1. Create custom script adapter in the form folder
         self.portal.REQUEST["form.widgets.title"] = u"Saver"
         self.portal.REQUEST["form.widgets.__name__"] = u"saver"
@@ -672,6 +675,12 @@ class SaverIntegrationTestCase(base.EasyFormFunctionalTestCase):
         # 2. Check that creation succeeded
         actions = get_actions(self.ff1)
         self.assertTrue("saver" in actions)
+
+        # Set a smaller batch size.
+        saver = actions["saver"]
+        saver.BatchSize = 3
+        set_actions(self.ff1, actions)
+        commit()
 
     def test_download_saveddata_view(self):
         self.browser.open(self.portal_url + "/test-folder/ff1/@@actions/saver/@@data")
@@ -741,6 +750,46 @@ class SaverIntegrationTestCase(base.EasyFormFunctionalTestCase):
         self.assertEqual(
             self.browser.contents, "Your E-Mail Address;Subject;Comments\r\n"
         )
+
+    def add_sample_data(self):
+        for i in range(1, 6):
+            self.browser.open(self.portal_url + "/test-folder/ff1")
+            self.browser.getControl(name="form.widgets.replyto").value = \
+                "me%d@example.org" % i
+            self.browser.getControl(name="form.widgets.topic").value = "Subject %d" % i
+            self.browser.getControl(name="form.widgets.comments").value = \
+                "Comments %d" % i
+            self.browser.getControl(name="form.buttons.submit").click()
+            self.assertIn("Thanks for your input.", self.browser.contents)
+
+    def test_view_saveddata_batched(self):
+        self.add_sample_data()
+        self.browser.open(
+            self.portal_url + "/test-folder/ff1/@@actions/saver/@@data"
+        )
+        with open('/tmp/test2.html', 'w') as testfile:
+            testfile.write(self.browser.contents)
+        self.assertTrue("Saved Data" in self.browser.contents)
+        self.assertTrue("me1@example.org" in self.browser.contents)
+        self.assertTrue("Subject 1" in self.browser.contents)
+        self.assertTrue("Comments 1" in self.browser.contents)
+        self.assertTrue("me2@example.org" in self.browser.contents)
+        self.assertTrue("me3@example.org" in self.browser.contents)
+        # We have a batch size of three, so the remaining two
+        # should not be visible.
+        self.assertFalse("me4@example.org" in self.browser.contents)
+        self.assertFalse("me5@example.org" in self.browser.contents)
+
+        # Go to the next batch
+        self.browser.getLink("Next 2 items").click()
+        self.assertTrue("Saved Data" in self.browser.contents)
+        self.assertFalse("me1@example.org" in self.browser.contents)
+        self.assertFalse("me2@example.org" in self.browser.contents)
+        self.assertFalse("me3@example.org" in self.browser.contents)
+        self.assertTrue("me4@example.org" in self.browser.contents)
+        self.assertTrue("me5@example.org" in self.browser.contents)
+        self.assertTrue("Subject 4" in self.browser.contents)
+        self.assertTrue("Comments 5" in self.browser.contents)
 
     # this test depends on internals of zope.testbrowser controls
     def test_download_saveddata_suggests_csv_delimiter_defines_maxlength(self):


### PR DESCRIPTION
On a client site I have a form with 12 questions and almost 700 entries and this takes over 40 seconds to load. Downloading the csv data takes just 4 seconds.

By default the page now uses a batch size of 10.
For good measure, you can override this by passing `?batch_size=x` in the url, but this gets lost when you use the batch navigation to go to the next page. This is because it is not supported by the standard `CrudBatchView` from `plone.z3cform`.