### PR TITLE
allow editors to remove a fieldset in easyform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 4.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Allow editors to remove fieldset
+  [ThibautBorn]
 
 
 4.3.0 (2024-12-13)

--- a/src/collective/easyform/browser/fields.zcml
+++ b/src/collective/easyform/browser/fields.zcml
@@ -31,6 +31,13 @@
       class="plone.schemaeditor.browser.schema.add_fieldset.FieldsetAddFormPage"
       layer="..interfaces.IEasyFormLayer"
       />
+   <browser:page
+      name="delete-fieldset"
+      for="collective.easyform.interfaces.IEasyFormFieldsContext"
+      permission="cmf.ModifyPortalContent"
+      class="plone.schemaeditor.browser.schema.delete_fieldset.DeleteFieldset"
+      layer="..interfaces.IEasyFormLayer"
+      />
   <browser:page
       name="edit"
       for="collective.easyform.interfaces.IEasyFormFieldContext"


### PR DESCRIPTION
context: this permission wasn't set since the delete-fieldset option was added to plone.schemaeditor