### PR TITLE
Enables the SelectFieldWidget (Select2 pattern) option on IChoice field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Enables the SelectFieldWidget (Select2 pattern) option on IChoice field
+  [sauzher]
 
 
 3.2.1 (2022-12-01)

--- a/src/collective/easyform/browser/widgets.zcml
+++ b/src/collective/easyform/browser/widgets.zcml
@@ -124,6 +124,13 @@
       factory="z3c.form.browser.radio.RadioFieldWidget"
       />
 
+  <!-- add SelectFieldWidget for IChoice to enable Select2 pattern widget -->
+  <adapter
+        for="zope.schema.interfaces.IChoice
+             *"
+        factory="plone.app.z3cform.widget.SelectFieldWidget"
+        />
+
   <configure zcml:condition="installed plone.formwidget.recaptcha">
     <adapter
         provides="z3c.form.interfaces.IFieldWidget"


### PR DESCRIPTION
![immagine](https://github.com/user-attachments/assets/bf3fcf01-b8df-48d8-876c-56e2e3707318)

![immagine](https://github.com/user-attachments/assets/7da2157f-ca8b-4341-9009-8e5edda58a55)

adds the `plone.app.z3cform.widget.SelectFieldWidget` value option to the widget selection on IChoice fields.


