### PR TITLE
Pin more versions in the test buildout.

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,5 @@
 [buildout]
-extends = tests-6.0.x.cfg
+extends = tests-6.1.x.cfg
 
 parts +=
     releaser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-zc.buildout==4.1.9
+zc.buildout==4.1.12
 setuptools==78.1.1

--- a/tests-6.0.x.cfg
+++ b/tests-6.0.x.cfg
@@ -1,4 +1,6 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.0.x.cfg
+    https://dist.plone.org/release/6.0-latest/versions-extra.cfg
+    https://dist.plone.org/release/6.0-latest/versions-ecosystem.cfg
     base.cfg

--- a/tests-6.1.x.cfg
+++ b/tests-6.1.x.cfg
@@ -1,4 +1,11 @@
 [buildout]
 extends =
     https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-6.1.x.cfg
+    https://dist.plone.org/release/6.1-latest/versions-extra.cfg
+    https://dist.plone.org/release/6.1-latest/versions-ecosystem.cfg
     base.cfg
+
+[versions]
+# The standard Products.validation = 3.0.0 from Plone 6.1.3 gives a
+# TypeError: 'mappingproxy' object does not support item assignment
+Products.validation = 3.0.1


### PR DESCRIPTION
I ran the [GHA on master](https://github.com/collective/collective.easyform/actions/runs/20917535047/job/60094682660), and this worked on Plone 6.0, but failed on 6.1.  

We were missing the pins for extra and ecosystem versions. This meant we got too new versions for `cmarkgfm`, `Products.PrintingMailHost` and some others.

Also pin Products.validation = 3.0.1 on 6.1, to avoid TypeErrors.

