### PR TITLE
Include form name in the filename of the save data download.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 4.5.1 (unreleased)
 ------------------
 
+- Include form name in the filename of the save data download.  [maurits]
 - Remove usage of the ``six`` compatibility library.  [maurits]
 - Update deprecated imports for Plone 6.0 and higher.  [maurits]
 

--- a/src/collective/easyform/actions.py
+++ b/src/collective/easyform/actions.py
@@ -648,6 +648,11 @@ class SaveData(Action):
         super().__init__(**kw)
 
     @property
+    def name_for_download(self):
+        context = get_context(self)
+        return f"{context.__name__}-{self.__name__}"
+
+    @property
     def _storage(self):
         context = get_context(self)
         if not hasattr(context, "_inputStorage"):
@@ -774,7 +779,7 @@ class SaveData(Action):
         # """
         response.setHeader(
             "Content-Disposition",
-            'attachment; filename="{}.csv"'.format(self.__name__),
+            f'attachment; filename="{self.name_for_download}.csv"',
         )
         response.setHeader("Content-Type", "text/comma-separated-values")
         value = self.getSavedFormInputForEdit(
@@ -789,7 +794,7 @@ class SaveData(Action):
         # """
         response.setHeader(
             "Content-Disposition",
-            'attachment; filename="{}.tsv"'.format(self.__name__),
+            f'attachment; filename="{self.name_for_download}.tsv"',
         )
         response.setHeader("Content-Type", "text/tab-separated-values")
         value = self.getSavedFormInputForEdit(
@@ -804,7 +809,7 @@ class SaveData(Action):
         # """
         response.setHeader(
             "Content-Disposition",
-            'attachment; filename="{}.xlsx"'.format(self.__name__),
+            f'attachment; filename="{self.name_for_download}.xlsx"',
         )
 
         response.setHeader(

--- a/src/collective/easyform/tests/testSaver.py
+++ b/src/collective/easyform/tests/testSaver.py
@@ -271,7 +271,7 @@ class SaveDataTestCase(BaseSaveData):
         saver.download(request.response, delimiter=",")
         res = request.response.stdout.getvalue().decode("utf-8")
         self.assertTrue("Content-Type: text/comma-separated-values" in res)
-        self.assertTrue('Content-Disposition: attachment; filename="saver.csv"' in res)
+        self.assertTrue('Content-Disposition: attachment; filename="ff1-saver.csv"' in res)
         self.assertTrue(saver.getSavedFormInputForEdit() in res)
 
     def testSaverDownloadTSV(self):
@@ -297,7 +297,7 @@ class SaveDataTestCase(BaseSaveData):
         saver.download(request.response)
         res = request.response.stdout.getvalue().decode("utf-8")
         self.assertTrue("Content-Type: text/tab-separated-values" in res)
-        self.assertTrue('Content-Disposition: attachment; filename="saver.tsv"' in res)
+        self.assertTrue('Content-Disposition: attachment; filename="ff1-saver.tsv"' in res)
         self.assertTrue(saver.getSavedFormInputForEdit(delimiter="\t") in res)
 
     @unittest.skipUnless(HAS_OPENPYXL, "Requires openpyxl")
@@ -333,7 +333,7 @@ class SaveDataTestCase(BaseSaveData):
         )
         self.assertEqual(
             request.response.headers["content-disposition"],
-            'attachment; filename="saver.xlsx"',
+            'attachment; filename="ff1-saver.xlsx"',
         )
 
         wb = load_workbook(res)
@@ -370,7 +370,7 @@ class SaveDataTestCase(BaseSaveData):
         saver.download(request.response, delimiter=",")
         res = request.response.stdout.getvalue().decode("utf-8")
         self.assertTrue("Content-Type: text/comma-separated-values" in res)
-        self.assertTrue('Content-Disposition: attachment; filename="saver.csv"' in res)
+        self.assertTrue('Content-Disposition: attachment; filename="ff1-saver.csv"' in res)
         self.assertTrue(saver.getSavedFormInputForEdit(header=True) in res)
 
     def testSaverDownloadExtraData(self):
@@ -396,7 +396,7 @@ class SaveDataTestCase(BaseSaveData):
         saver.download(request.response, delimiter=",")
         res = request.response.stdout.getvalue().decode("utf-8")
         self.assertTrue("Content-Type: text/comma-separated-values" in res)
-        self.assertTrue('Content-Disposition: attachment; filename="saver.csv"' in res)
+        self.assertTrue('Content-Disposition: attachment; filename="ff1-saver.csv"' in res)
         self.assertTrue(saver.getSavedFormInputForEdit() in res)
 
     def testSaverSavedFormInput(self):


### PR DESCRIPTION
For example instead of `saver.csv`, you get `my-form-saver.csv`.

This builds on my branch of PR #464.  It is best to review and merge that PR first.  Then the current PR should automatically get updated to target master.