### PR TITLE
save field and action xml as string instead of bytes when editing xml directly

### DIFF
--- a/src/collective/easyform/browser/fields.py
+++ b/src/collective/easyform/browser/fields.py
@@ -211,8 +211,9 @@ class ModelEditorView(BrowserView):
 
             # clean up formatting sins
             source = etree.tostring(
-                root, pretty_print=True, xml_declaration=True, encoding="utf8"
+                root, pretty_print=True, encoding=str
             )
             # and save
             self.save(source)
+
         return self.template()


### PR DESCRIPTION
We (@gotcha and me) noticed that the fields xml and actions xml get saved as a string when you edit the fields and actions through the interface (/fields and /actions)
but the fields and actions xml gets saved as bytes when you edit the xml directly (through the @@fields/@@modeleditor and @@actions/@@modeleditor)
This seems like a bug to us, since we always expect a string.